### PR TITLE
New default branch `main`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "restricted",
-  "baseBranch": "develop",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,9 +5,9 @@ permissions:
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main]
   pull_request:
-    branches: [ main, develop ]
+    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   push:
     branches:
-      - develop
+      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -36,7 +36,7 @@ jobs:
         with:
           publish: npm run release
           commitMode: github-api # the api is required to get signed commits on changeset bot's workflow
-          branch: develop
+          branch: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: 0


### PR DESCRIPTION
This PR updates references to our previous default branch `develop` to match our new default branch, `main`