### PR TITLE
Update tokens package and corresponding variable names

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -36,39 +36,39 @@
           "cssProperties": [
             {
               "description": "Sets banner background color.",
-              "name": "--usa-banner-background-color"
+              "name": "--ogds-banner-background-color"
             },
             {
               "description": "Sets the background color for the close control on smaller viewports.",
-              "name": "--usa-banner-button-close-background-color"
+              "name": "--ogds-banner-button-close-background-color"
             },
             {
               "description": "Sets banner focus outline color.",
-              "name": "--usa-banner-focus-outline-color"
+              "name": "--ogds-banner-focus-outline-color"
             },
             {
               "description": "Sets banner font family.",
-              "name": "--usa-banner-font-family"
+              "name": "--ogds-banner-font-family"
             },
             {
               "description": "Sets the color for the official government domain icon in the expanded state of the banner.",
-              "name": "--usa-banner-icon-gov-color"
+              "name": "--ogds-banner-icon-gov-color"
             },
             {
               "description": "Sets the color for the https icon in the expanded state of the banner.",
-              "name": "--usa-banner-icon-https-color"
+              "name": "--ogds-banner-icon-https-color"
             },
             {
               "description": "Sets the default link color.",
-              "name": "--usa-banner-link-color"
+              "name": "--ogds-banner-link-color"
             },
             {
               "description": "Sets the default link color.",
-              "name": "--usa-banner-link-hover-color"
+              "name": "--ogds-banner-link-hover-color"
             },
             {
               "description": "Sets the default text color.",
-              "name": "--usa-banner-text-color"
+              "name": "--ogds-banner-text-color"
             }
           ],
           "slots": [
@@ -259,6 +259,33 @@
           "declaration": {
             "name": "UsaBanner",
             "module": "src/components/usa-banner/index.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/usa-header/index.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "UsaHeader",
+          "members": [],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "UsaHeader",
+          "declaration": {
+            "name": "UsaHeader",
+            "module": "src/components/usa-header/index.ts"
           }
         }
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@uswds/elements",
       "version": "1.0.0-alpha.6",
       "dependencies": {
-        "@ogds/tokens": "^1.0.0-alpha.1",
+        "@ogds/tokens": "^1.0.0-alpha.2",
         "@uswds/uswds": "^3.13.0",
         "lit": "^3.3.2",
         "sass": "^1.97.3"
@@ -16,7 +16,8 @@
       "devDependencies": {
         "@changesets/cli": "^2.29.8",
         "@custom-elements-manifest/analyzer": "^0.11.0",
-        "@eslint/css": "^1.0.0",
+        "@eslint/css": "^1.1.0",
+        "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.58.2",
         "@storybook/addon-a11y": "^10.2.10",
         "@storybook/addon-docs": "^10.2.10",
@@ -1913,9 +1914,9 @@
       }
     },
     "node_modules/@eslint/css": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/css/-/css-1.0.0.tgz",
-      "integrity": "sha512-2MjyL517F1wrLrmmfaFntKKiImudiXW6Dd80oE7VRIRu64bT5YieRs+WPgdZy9m8izs/tSUqi3j2mBnjUrqJfA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/css/-/css-1.1.0.tgz",
+      "integrity": "sha512-sNwfLcU3nKXv/v2YglqujwMU4Iv3BDhxldNUd/2FckVab0zdvc9pPlKWxjR6Ap/EU+Y8Pdu853iwvcUpemRhRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1939,6 +1940,27 @@
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -3176,9 +3198,9 @@
       }
     },
     "node_modules/@ogds/tokens": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@ogds/tokens/-/tokens-1.0.0-alpha.1.tgz",
-      "integrity": "sha512-TrqRn5q383iDy8MGet7bWgKV4GhcLRfS74QiOy4mcVGTiePR6Q47gTQgLcfMdOiPA9cHzK3ipNcJIqpTEzwmxw=="
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@ogds/tokens/-/tokens-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-pLDf3ooinQQNgrjodxvSFj/NTgTqpAOQSG4nqidR62POvlyDXOErbLXBDVymOrAGDRHpECtAq4NG3KoXrKBIqA=="
     },
     "node_modules/@oxc-resolver/binding-android-arm-eabi": {
       "version": "11.13.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "vite:preview": "vite preview --config ./config/vite.config.ts"
   },
   "dependencies": {
-    "@ogds/tokens": "^1.0.0-alpha.1",
+    "@ogds/tokens": "^1.0.0-alpha.2",
     "@uswds/uswds": "^3.13.0",
     "lit": "^3.3.2",
     "sass": "^1.97.3"
@@ -65,7 +65,8 @@
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
     "@custom-elements-manifest/analyzer": "^0.11.0",
-    "@eslint/css": "^1.0.0",
+    "@eslint/css": "^1.1.0",
+    "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.58.2",
     "@storybook/addon-a11y": "^10.2.10",
     "@storybook/addon-docs": "^10.2.10",

--- a/src/components/usa-banner/index.ts
+++ b/src/components/usa-banner/index.ts
@@ -94,15 +94,15 @@ const USA_BANNER_TRANSLATIONS: Record<
  * @attribute {string} label - The custom aria label users can override.
  * @attribute {string} tld - The top level domain for the site.
  *
- * @cssprop --usa-banner-background-color - Sets banner background color.
- * @cssprop --usa-banner-button-close-background-color - Sets the background color for the close control on smaller viewports.
- * @cssprop --usa-banner-focus-outline-color - Sets banner focus outline color.
- * @cssprop --usa-banner-font-family - Sets banner font family.
- * @cssprop --usa-banner-icon-gov-color - Sets the color for the official government domain icon in the expanded state of the banner.
- * @cssprop --usa-banner-icon-https-color - Sets the color for the https icon in the expanded state of the banner.
- * @cssprop --usa-banner-link-color - Sets the default link color.
- * @cssprop --usa-banner-link-hover-color - Sets the default link color.
- * @cssprop --usa-banner-text-color - Sets the default text color.
+ * @cssprop --ogds-banner-background-color - Sets banner background color.
+ * @cssprop --ogds-banner-button-close-background-color - Sets the background color for the close control on smaller viewports.
+ * @cssprop --ogds-banner-focus-outline-color - Sets banner focus outline color.
+ * @cssprop --ogds-banner-font-family - Sets banner font family.
+ * @cssprop --ogds-banner-icon-gov-color - Sets the color for the official government domain icon in the expanded state of the banner.
+ * @cssprop --ogds-banner-icon-https-color - Sets the color for the https icon in the expanded state of the banner.
+ * @cssprop --ogds-banner-link-color - Sets the default link color.
+ * @cssprop --ogds-banner-link-hover-color - Sets the default link color.
+ * @cssprop --ogds-banner-text-color - Sets the default text color.
  *
  * @slot banner-text - The text for official government website text.
  * @slot banner-action - Action text label "Here's how you know."
@@ -210,11 +210,11 @@ export class UsaBanner extends LitElement {
     css`
       :host {
         /** Icons */
-        --usa-icon-close: url("${unsafeCSS(iconClose)}");
-        --usa-icon-expand-less: url("${unsafeCSS(iconExpandLess)}");
-        --usa-icon-expand-more: url("${unsafeCSS(iconExpandMore)}");
-        --usa-icon-gov: url("${unsafeCSS(iconDotGov)}");
-        --usa-icon-https: url("${unsafeCSS(iconHttps)}");
+        --ogds-icon-close: url("${unsafeCSS(iconClose)}");
+        --ogds-icon-expand-less: url("${unsafeCSS(iconExpandLess)}");
+        --ogds-icon-expand-more: url("${unsafeCSS(iconExpandMore)}");
+        --ogds-icon-gov: url("${unsafeCSS(iconDotGov)}");
+        --ogds-icon-https: url("${unsafeCSS(iconHttps)}");
       }
     `,
     breakpointTokens,

--- a/src/components/usa-banner/usa-banner.css
+++ b/src/components/usa-banner/usa-banner.css
@@ -1,25 +1,25 @@
 :host {
   /** Component tokens */
-  --usa-banner-background-color: var(--usa-color-base-lightest, #f0f0f0);
-  --usa-banner-button-close-background-color: var(
-    --usa-color-base-lighter,
+  --ogds-banner-background-color: var(--ogds-color-base-lightest, #f0f0f0);
+  --ogds-banner-button-close-background-color: var(
+    --ogds-color-base-lighter,
     #dfe1e2
   );
-  --usa-banner-focus-outline-color: var(--usa-color-blue-vivid-40, #2491ff);
-  --usa-banner-font-family:
+  --ogds-banner-focus-outline-color: var(--ogds-color-blue-vivid-40, #2491ff);
+  --ogds-banner-font-family:
     system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
     Arial, sans-serif;
-  --usa-banner-font-size-xs: 0.75rem;
-  --usa-banner-font-size-sm: 0.875rem;
-  --usa-banner-font-size-base: 0.94rem;
-  --usa-banner-icon-gov-color: var(--usa-color-blue-50, #2378c3);
-  --usa-banner-icon-https-color: var(--usa-color-green-vivid-40, #719f2a);
-  --usa-banner-line-height-sm: 1.2;
-  --usa-banner-line-height-base: 1.6;
-  --usa-banner-link-color: var(--usa-color-blue-vivid-60, #005ea2);
-  --usa-banner-link-hover-color: var(--usa-color-blue-warm-vivid-70, #1a4480);
-  --usa-banner-max-width: var(--usa-breakpoint-desktop);
-  --usa-banner-text-color: var(--usa-color-base-darkest, #1b1b1b);
+  --ogds-banner-font-size-xs: 0.75rem;
+  --ogds-banner-font-size-sm: 0.875rem;
+  --ogds-banner-font-size-base: 0.94rem;
+  --ogds-banner-icon-gov-color: var(--ogds-color-blue-50, #2378c3);
+  --ogds-banner-icon-https-color: var(--ogds-color-green-vivid-40, #719f2a);
+  --ogds-banner-line-height-sm: 1.2;
+  --ogds-banner-line-height-base: 1.6;
+  --ogds-banner-link-color: var(--ogds-color-blue-vivid-60, #005ea2);
+  --ogds-banner-link-hover-color: var(--ogds-color-blue-warm-vivid-70, #1a4480);
+  --ogds-banner-max-width: var(--ogds-breakpoint-desktop);
+  --ogds-banner-text-color: var(--ogds-color-base-darkest, #1b1b1b);
 
   /**
    * Icons
@@ -29,7 +29,7 @@
    * data URI. The variable definition below is an exception since it is an ad-hoc
    * icon that is not part of the USWDS icon library.
    */
-  --usa-icon-lock: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='52' height='64' viewBox='0 0 52 64' class='usa-banner__lock-image' role='img' aria-labelledby='banner-lock-description-default' focusable='false'%3E%3Ctitle id='banner-lock-title-default'%3ELock%3C/title%3E%3Cdesc id='banner-lock-description-default'%3ELocked padlock icon%3C/desc%3E%3Cpath fill='%23000000' fill-rule='evenodd' d='M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z'%3E%3C/path%3E%3C/svg%3E");
+  --ogds-icon-lock: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='52' height='64' viewBox='0 0 52 64' class='usa-banner__lock-image' role='img' aria-labelledby='banner-lock-description-default' focusable='false'%3E%3Ctitle id='banner-lock-title-default'%3ELock%3C/title%3E%3Cdesc id='banner-lock-description-default'%3ELocked padlock icon%3C/desc%3E%3Cpath fill='%23000000' fill-rule='evenodd' d='M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z'%3E%3C/path%3E%3C/svg%3E");
 }
 
 * {
@@ -37,10 +37,10 @@
 }
 
 section {
-  background-color: var(--usa-banner-background-color);
+  background-color: var(--ogds-banner-background-color);
   box-sizing: border-box;
-  font-family: var(--usa-banner-font-family);
-  font-size: var(--usa-banner-font-size-xs);
+  font-family: var(--ogds-banner-font-family);
+  font-size: var(--ogds-banner-font-size-xs);
   text-align: start;
 }
 
@@ -52,7 +52,7 @@ section *::after {
 
 @media (width >= 40em) {
   section {
-    font-size: var(--usa-banner-font-size-xs);
+    font-size: var(--ogds-banner-font-size-xs);
     padding-block-end: 0;
   }
 }
@@ -72,19 +72,19 @@ section .grid-row {
    */
   grid-template-columns: repeat(
     auto-fit,
-    minmax(min(100%, calc(var(--usa-breakpoint-tablet) / 2)), 1fr)
+    minmax(min(100%, calc(var(--ogds-breakpoint-tablet) / 2)), 1fr)
   );
 }
 
 @media (width >= 40em) {
   section .grid-row {
-    gap: var(--usa-spacing-2);
+    gap: var(--ogds-spacing-2);
   }
 }
 
 @media (width >= 64em) {
   section .grid-row {
-    gap: calc(var(--usa-spacing-05) / 2);
+    gap: calc(var(--ogds-spacing-05) / 2);
   }
 }
 
@@ -109,36 +109,36 @@ section .grid-row {
 
 section .tablet\:grid-col-6 {
   flex: 0 0 auto;
-  gap: var(--usa-spacing-1);
+  gap: var(--ogds-spacing-1);
   width: 100%;
 }
 
 header,
 .content {
-  color: var(--usa-banner-text-color);
+  color: var(--ogds-banner-text-color);
 }
 
 .content {
-  font-size: var(--usa-banner-font-size-base);
-  line-height: var(--usa-banner-line-height-base);
+  font-size: var(--ogds-banner-font-size-base);
+  line-height: var(--ogds-banner-line-height-base);
   margin-inline: auto;
-  max-width: var(--usa-banner-max-width);
+  max-width: var(--ogds-banner-max-width);
   overflow: hidden;
-  padding-block-end: var(--usa-spacing-2);
-  padding-block-start: var(--usa-spacing-05);
-  padding-inline: var(--usa-spacing-1);
+  padding-block-end: var(--ogds-spacing-2);
+  padding-block-start: var(--ogds-spacing-05);
+  padding-inline: var(--ogds-spacing-1);
   width: 100%;
 }
 
 @media (width >= 40em) {
   .content {
-    padding-block: var(--usa-spacing-3);
+    padding-block: var(--ogds-spacing-3);
   }
 }
 
 @media (width >= 64em) {
   .content {
-    padding-inline: var(--usa-spacing-4);
+    padding-inline: var(--ogds-spacing-4);
   }
 }
 
@@ -151,9 +151,9 @@ header,
   display: flex;
   flex-wrap: nowrap;
   margin-inline: auto;
-  max-width: var(--usa-banner-max-width);
-  padding-inline-end: var(--usa-spacing-05);
-  padding-inline-start: var(--usa-spacing-2);
+  max-width: var(--ogds-banner-max-width);
+  padding-inline-end: var(--ogds-spacing-05);
+  padding-inline-start: var(--ogds-spacing-2);
 }
 
 @media (width >= 40em) {
@@ -164,45 +164,45 @@ header,
 
 @media (width >= 64em) {
   .inner {
-    padding-inline: var(--usa-spacing-4);
+    padding-inline: var(--ogds-spacing-4);
   }
 }
 
 header {
-  font-size: var(--usa-banner-font-size-xs);
+  font-size: var(--ogds-banner-font-size-xs);
   font-weight: 400;
-  min-height: var(--usa-size-touch-target);
-  padding-block: var(--usa-spacing-1);
+  min-height: var(--ogds-size-touch-target);
+  padding-block: var(--ogds-spacing-1);
   position: relative;
 }
 
 @media (width >= 40em) {
   header {
     min-height: 0;
-    padding-block: var(--usa-spacing-05);
+    padding-block: var(--ogds-spacing-05);
   }
 }
 
 .header-text {
-  font-size: var(--usa-banner-font-size-xs);
-  line-height: var(--usa-banner-line-height-sm);
+  font-size: var(--ogds-banner-font-size-xs);
+  line-height: var(--ogds-banner-line-height-sm);
   margin-block: 0;
 }
 
 .header-flag {
   float: left;
-  margin-inline-end: var(--usa-spacing-1);
+  margin-inline-end: var(--ogds-spacing-1);
   padding-block-start: 0;
-  width: var(--usa-spacing-2);
+  width: var(--ogds-spacing-2);
 }
 
 .header-action {
   background: none;
   border: none;
-  color: var(--usa-banner-link-color);
+  color: var(--ogds-banner-link-color);
   cursor: pointer;
   font: inherit;
-  line-height: var(--usa-banner-line-height-sm);
+  line-height: var(--ogds-banner-line-height-sm);
   margin-block-end: 0;
   margin-block-start: 2px;
   padding: 0;
@@ -210,7 +210,7 @@ header {
 }
 
 .header-action:hover {
-  color: var(--usa-banner-link-hover-color);
+  color: var(--ogds-banner-link-hover-color);
 }
 
 .header-action::after {
@@ -218,7 +218,7 @@ header {
   content: "";
   display: inline-block;
   height: 1rem;
-  mask-image: var(--usa-icon-expand-more);
+  mask-image: var(--ogds-icon-expand-more);
   mask-position: center;
   mask-repeat: no-repeat;
   mask-size: 1rem 1rem;
@@ -247,13 +247,15 @@ header {
 }
 
 header.expanded {
-  padding-inline-end: calc(var(--usa-size-touch-target) + var(--usa-spacing-1));
+  padding-inline-end: calc(
+    var(--ogds-size-touch-target) + var(--ogds-spacing-1)
+  );
 }
 
 @media (width >= 40em) {
   header.expanded {
     display: block;
-    font-size: var(--usa-banner-font-size-sm);
+    font-size: var(--ogds-banner-font-size-sm);
     font-weight: 400;
     min-height: 0;
     padding-inline-end: 0;
@@ -278,14 +280,14 @@ button {
   background: none;
   border: none;
   bottom: 0;
-  color: var(--usa-banner-link-color);
+  color: var(--ogds-banner-link-color);
   cursor: pointer;
   display: block;
   font: inherit;
-  font-size: var(--usa-banner-font-size-xs);
+  font-size: var(--ogds-banner-font-size-xs);
   height: auto;
   left: 0;
-  line-height: var(--usa-banner-line-height-sm);
+  line-height: var(--ogds-banner-line-height-sm);
   outline: inherit;
   padding: 0;
   padding-block-start: 0;
@@ -297,7 +299,7 @@ button {
 }
 
 button:hover {
-  color: var(--usa-banner-link-hover-color);
+  color: var(--ogds-banner-link-hover-color);
 }
 
 @media (width <= 39.99em) {
@@ -311,7 +313,7 @@ button:hover {
 }
 
 button:not([disabled]):focus {
-  outline: var(--usa-spacing-05) solid var(--usa-banner-focus-outline-color);
+  outline: var(--ogds-spacing-05) solid var(--ogds-banner-focus-outline-color);
 }
 
 @media (width >= 40em) {
@@ -319,7 +321,7 @@ button:not([disabled]):focus {
     bottom: auto;
     display: inline;
     left: auto;
-    margin-inline-start: var(--usa-spacing-1);
+    margin-inline-start: var(--ogds-spacing-1);
     position: relative;
     top: auto;
   }
@@ -330,7 +332,7 @@ button:not([disabled]):focus {
     display: inline-block;
     height: 1rem;
     margin-block: 0;
-    mask-image: var(--usa-icon-expand-more);
+    mask-image: var(--ogds-icon-expand-more);
     mask-position: center;
     mask-repeat: no-repeat;
     mask-size: contain;
@@ -370,31 +372,31 @@ button[aria-expanded="true"]:hover {
 
 @media (width <= 39.99em) {
   button[aria-expanded="true"]::before {
-    background-color: var(--usa-banner-button-close-background-color);
+    background-color: var(--ogds-banner-button-close-background-color);
     bottom: 0;
     content: "";
     display: block;
-    height: var(--usa-size-touch-target);
+    height: var(--ogds-size-touch-target);
     position: absolute;
     right: 0;
     top: 0;
-    width: var(--usa-size-touch-target);
+    width: var(--ogds-size-touch-target);
   }
 
   button[aria-expanded="true"]::after {
-    background-color: var(--usa-banner-link-color);
+    background-color: var(--ogds-banner-link-color);
     bottom: 0;
     content: "";
     display: block;
-    height: var(--usa-size-touch-target);
-    mask-image: var(--usa-icon-close);
+    height: var(--ogds-size-touch-target);
+    mask-image: var(--ogds-icon-close);
     mask-position: center;
     mask-repeat: no-repeat;
     mask-size: 1.5rem 1.5rem;
     position: absolute;
     right: 0;
     top: 0;
-    width: var(--usa-size-touch-target);
+    width: var(--ogds-size-touch-target);
   }
 }
 
@@ -407,7 +409,7 @@ button[aria-expanded="true"]:hover {
 
   button[aria-expanded="true"]::after,
   button[aria-expanded="true"]:hover::after {
-    mask-image: var(--usa-icon-expand-less);
+    mask-image: var(--ogds-icon-expand-less);
     position: absolute;
   }
 }
@@ -445,7 +447,7 @@ button[aria-expanded="true"]:hover {
   align-items: flex-start;
   display: flex;
   max-width: 62ex;
-  padding-block-start: var(--usa-spacing-2);
+  padding-block-start: var(--ogds-spacing-2);
 }
 
 @media (width <= 39.99em) {
@@ -457,12 +459,12 @@ button[aria-expanded="true"]:hover {
 @media (width >= 40em) {
   .guidance {
     padding-block-start: 0;
-    padding-inline-end: var(--usa-spacing-1);
+    padding-inline-end: var(--ogds-spacing-1);
   }
 }
 
 .icon {
-  width: var(--usa-spacing-5);
+  width: var(--ogds-spacing-5);
 }
 
 .icon-lock,
@@ -473,7 +475,7 @@ button[aria-expanded="true"]:hover {
   background-size: cover;
   display: inline-block;
   height: 1.5ex;
-  mask-image: var(--usa-icon-lock);
+  mask-image: var(--ogds-icon-lock);
   mask-position: center;
   mask-repeat: no-repeat;
   mask-size: cover;
@@ -482,28 +484,28 @@ button[aria-expanded="true"]:hover {
 
 .icon-gov,
 .icon-https {
-  padding-inline-start: calc(var(--usa-spacing-5) + var(--usa-spacing-1));
+  padding-inline-start: calc(var(--ogds-spacing-5) + var(--ogds-spacing-1));
   position: relative;
 
   &::before {
     content: "";
     display: inline-block;
-    height: var(--usa-spacing-5);
+    height: var(--ogds-spacing-5);
     left: 0;
     mask-repeat: no-repeat;
     mask-size: contain;
     position: absolute;
     top: 0;
-    width: var(--usa-spacing-5);
+    width: var(--ogds-spacing-5);
   }
 }
 
 .icon-gov::before {
-  background-color: var(--usa-banner-icon-gov-color);
-  mask-image: var(--usa-icon-gov);
+  background-color: var(--ogds-banner-icon-gov-color);
+  mask-image: var(--ogds-icon-gov);
 }
 
 .icon-https::before {
-  background-color: var(--usa-banner-icon-https-color);
-  mask-image: var(--usa-icon-https);
+  background-color: var(--ogds-banner-icon-https-color);
+  mask-image: var(--ogds-icon-https);
 }

--- a/src/components/usa-banner/usa-banner.stories.ts
+++ b/src/components/usa-banner/usa-banner.stories.ts
@@ -99,16 +99,16 @@ export const CustomThemeExample = {
     },
   },
   args: {
-    "--usa-banner-background-color": "#0f191c", // blue-cool-90
-    "--usa-banner-button-close-background-color": "#002d3f", // blue-cool-80-vivid
-    "--usa-banner-focus-outline-color": "#52daf2", // cyan-20-vivid
-    "--usa-banner-font-family":
+    "--ogds-banner-background-color": "#0f191c", // blue-cool-90
+    "--ogds-banner-button-close-background-color": "#002d3f", // blue-cool-80-vivid
+    "--ogds-banner-focus-outline-color": "#52daf2", // cyan-20-vivid
+    "--ogds-banner-font-family":
       "ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace",
-    "--usa-banner-link-hover-color": "#c3ebfa", // blue-cool-10-vivid
-    "--usa-banner-text-color": "#ffffff",
-    "--usa-banner-link-color": "#97d4ea", // blue-cool-20-vivid
-    "--usa-banner-icon-gov-color": "#29e1cb", // mint-cool-20-vivid
-    "--usa-banner-icon-https-color": "#29e1cb", // mint-cool-20-vivid
+    "--ogds-banner-link-hover-color": "#c3ebfa", // blue-cool-10-vivid
+    "--ogds-banner-text-color": "#ffffff",
+    "--ogds-banner-link-color": "#97d4ea", // blue-cool-20-vivid
+    "--ogds-banner-icon-gov-color": "#29e1cb", // mint-cool-20-vivid
+    "--ogds-banner-icon-https-color": "#29e1cb", // mint-cool-20-vivid
   },
 };
 


### PR DESCRIPTION
<!---
Step 1 - Title this PR with the following format:
Web components : [Brief statement describing what this pull request does]
eg: "Web components: Update dependencies"
 -->

# Summary

Updated to the most recent alpha of `@ogds/tokens` which has a breaking change (the default token prefix changed from `usa` to `ogds`), so updated the CSS accordingly.

## Preview

Here's the banner updated with the new token names, looking how it's supposed to look:

<img width="882" height="342" alt="image" src="https://github.com/user-attachments/assets/eb0e3aac-60c7-4253-a74f-4d59739dc972" />

## Problem statement

The most recent release of the OGDS tokens package changed the default token names from being prefixed with `usa` (as they were in USWDS Elements) to `ogds`. The change on the token side required updating this component styles in this package that consume those tokens, so that's what this PR does.

## Solution

Just find & replace!

## Testing and review

If you'd like to verify the changes, you can do so by pulling down these changes, running `npm i` and verifying that the banner looks as expected in Storybook.

## Dependency updates

| Dependency name              | Previous version | New version |
| :---------------------------- | :--------------: | :---------: |
| `@ogds/tokens` |     1.0.0.alpha.1      |   1.0.0.alpha.2   |

