### PR TITLE
Add accordion toggle component

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -22,6 +22,138 @@
             "name": "OgdsAccordion",
             "module": "src/components/index.ts"
           }
+        },
+        {
+          "kind": "js",
+          "name": "OgdsAccordionToggle",
+          "declaration": {
+            "name": "OgdsAccordionToggle",
+            "module": "src/components/index.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/ogds-accordion/index.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "OgdsAccordion",
+          "cssProperties": [
+            {
+              "description": "Border used in the bordered variant.",
+              "name": "--ogds-accordion-border"
+            },
+            {
+              "description": "Padding for the expanded content area.",
+              "name": "--ogds-accordion-content-padding"
+            },
+            {
+              "description": "Icon shown when a panel is closed. Defaults to a chevron pointing down. CSS-only users must set this to a url() value pointing to their own icon asset.",
+              "name": "--ogds-accordion-icon-closed"
+            },
+            {
+              "description": "Icon shown when a panel is open. Defaults to a chevron pointing up. CSS-only users must set this to a url() value pointing to their own icon asset.",
+              "name": "--ogds-accordion-icon-open"
+            }
+          ],
+          "slots": [
+            {
+              "description": "The default (only) slot for the <ogds-accordion> expects one or more plain HTML <details> elements.",
+              "name": ""
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "useListSemantics",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "use-list-semantics"
+            },
+            {
+              "kind": "field",
+              "name": "headingLevel",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "attribute": "heading-level"
+            },
+            {
+              "kind": "field",
+              "name": "detailsChildren",
+              "type": {
+                "text": "HTMLCollectionOf<HTMLDetailsElement> | undefined"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "childRoles",
+              "type": {
+                "text": "Map<HTMLDetailsElement, Set<string>>"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "getDetailsChildren"
+            },
+            {
+              "kind": "method",
+              "name": "addListSemantics"
+            },
+            {
+              "kind": "method",
+              "name": "addHeadingSemantics"
+            },
+            {
+              "kind": "method",
+              "name": "applyChildRoles"
+            }
+          ],
+          "attributes": [
+            {
+              "type": {
+                "text": "boolean"
+              },
+              "description": "Adds `role=\"list\"` to the component and `role=\"listitem\"` to each `<details>` child, conveying the accordion as a list to assistive technologies. Mutually exclusive with `heading-level`.",
+              "name": "use-list-semantics",
+              "default": "false",
+              "fieldName": "useListSemantics",
+              "propName": "useListSemantics"
+            },
+            {
+              "type": {
+                "text": "number"
+              },
+              "description": "Sets a heading level for each accordion panel by adding `role=\"heading\"` and the corresponding `aria-level` to each `<summary>` element. Has no effect when set to `0` (the default). Mutually exclusive with `use-list-semantics`.",
+              "name": "heading-level",
+              "default": "0",
+              "fieldName": "headingLevel",
+              "propName": "headingLevel"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "ogds-accordion",
+          "customElement": true,
+          "summary": "The ogds-accordion component.\n\nApply these classes to `<ogds-accordion>` to enable variants:\n- `bordered` — adds a border to expanded content\n- `with-icon` — shows a chevron icon on each summary\n- `with-icon plus` — uses plus/minus icons instead of chevrons\n- `with-icon right` — aligns the icon to the right"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "OgdsAccordion",
+          "declaration": {
+            "name": "OgdsAccordion",
+            "module": "src/components/ogds-accordion/index.ts"
+          }
         }
       ]
     },
@@ -352,130 +484,6 @@
           "declaration": {
             "name": "OgdsBanner",
             "module": "src/components/ogds-banner/index.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/ogds-accordion/index.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "OgdsAccordion",
-          "cssProperties": [
-            {
-              "description": "Border used in the bordered variant.",
-              "name": "--ogds-accordion-border"
-            },
-            {
-              "description": "Padding for the expanded content area.",
-              "name": "--ogds-accordion-content-padding"
-            },
-            {
-              "description": "Icon shown when a panel is closed. Defaults to a chevron pointing down. CSS-only users must set this to a url() value pointing to their own icon asset.",
-              "name": "--ogds-accordion-icon-closed"
-            },
-            {
-              "description": "Icon shown when a panel is open. Defaults to a chevron pointing up. CSS-only users must set this to a url() value pointing to their own icon asset.",
-              "name": "--ogds-accordion-icon-open"
-            }
-          ],
-          "slots": [
-            {
-              "description": "The default (only) slot for the <ogds-accordion> expects one or more plain HTML <details> elements.",
-              "name": ""
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "useListSemantics",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "use-list-semantics"
-            },
-            {
-              "kind": "field",
-              "name": "headingLevel",
-              "type": {
-                "text": "number"
-              },
-              "default": "0",
-              "attribute": "heading-level"
-            },
-            {
-              "kind": "field",
-              "name": "detailsChildren",
-              "type": {
-                "text": "HTMLCollectionOf<HTMLDetailsElement> | undefined"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "childRoles",
-              "type": {
-                "text": "Map<HTMLDetailsElement, Set<string>>"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "getDetailsChildren"
-            },
-            {
-              "kind": "method",
-              "name": "addListSemantics"
-            },
-            {
-              "kind": "method",
-              "name": "addHeadingSemantics"
-            },
-            {
-              "kind": "method",
-              "name": "applyChildRoles"
-            }
-          ],
-          "attributes": [
-            {
-              "type": {
-                "text": "boolean"
-              },
-              "description": "Adds `role=\"list\"` to the component and `role=\"listitem\"` to each `<details>` child, conveying the accordion as a list to assistive technologies. Mutually exclusive with `heading-level`.",
-              "name": "use-list-semantics",
-              "default": "false",
-              "fieldName": "useListSemantics",
-              "propName": "useListSemantics"
-            },
-            {
-              "type": {
-                "text": "number"
-              },
-              "description": "Sets a heading level for each accordion panel by adding `role=\"heading\"` and the corresponding `aria-level` to each `<summary>` element. Has no effect when set to `0` (the default). Mutually exclusive with `use-list-semantics`.",
-              "name": "heading-level",
-              "default": "0",
-              "fieldName": "headingLevel",
-              "propName": "headingLevel"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "ogds-accordion",
-          "customElement": true,
-          "summary": "The ogds-accordion component.\n\nApply these classes to `<ogds-accordion>` to enable variants:\n- `bordered` — adds a border to expanded content\n- `with-icon` — shows a chevron icon on each summary\n- `with-icon plus` — uses plus/minus icons instead of chevrons\n- `with-icon right` — aligns the icon to the right"
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "OgdsAccordion",
-          "declaration": {
-            "name": "OgdsAccordion",
-            "module": "src/components/ogds-accordion/index.ts"
           }
         }
       ]

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -39,6 +39,16 @@
               "name": "button"
             }
           ],
+          "slots": [
+            {
+              "description": "Button label when all panels are collapsed. Defaults to \"Expand All\".",
+              "name": "expand-label"
+            },
+            {
+              "description": "Button label when one or more panels are open. Defaults to \"Collapse All\".",
+              "name": "collapse-label"
+            }
+          ],
           "members": [
             {
               "kind": "field",
@@ -51,30 +61,21 @@
             },
             {
               "kind": "field",
-              "name": "expandLabel",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"Expand All\"",
-              "attribute": "expand-label"
-            },
-            {
-              "kind": "field",
-              "name": "collapseLabel",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"Collapse All\"",
-              "attribute": "collapse-label"
-            },
-            {
-              "kind": "field",
               "name": "_anyOpen",
               "type": {
                 "text": "boolean"
               },
               "privacy": "private",
               "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "_observer",
+              "type": {
+                "text": "MutationObserver | null"
+              },
+              "privacy": "private",
+              "default": "null"
             },
             {
               "kind": "method",
@@ -95,26 +96,6 @@
               "default": "\"\"",
               "fieldName": "controls",
               "propName": "controls"
-            },
-            {
-              "type": {
-                "text": "string"
-              },
-              "description": "Button label when all panels are collapsed. Defaults to \"Expand All\".",
-              "name": "expand-label",
-              "default": "\"Expand All\"",
-              "fieldName": "expandLabel",
-              "propName": "expandLabel"
-            },
-            {
-              "type": {
-                "text": "string"
-              },
-              "description": "Button label when one or more panels are open. Defaults to \"Collapse All\".",
-              "name": "collapse-label",
-              "default": "\"Collapse All\"",
-              "fieldName": "collapseLabel",
-              "propName": "collapseLabel"
             }
           ],
           "superclass": {
@@ -133,157 +114,6 @@
           "declaration": {
             "name": "OgdsAccordionToggle",
             "module": "src/components/ogds-accordion-toggle/index.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/ogds-accordion/index.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "OgdsAccordion",
-          "cssProperties": [
-            {
-              "description": "Border used in the bordered variant.",
-              "name": "--ogds-accordion-border"
-            },
-            {
-              "description": "Padding for the expanded content area.",
-              "name": "--ogds-accordion-content-padding"
-            },
-            {
-              "description": "Icon shown when a panel is closed. Defaults to a chevron pointing down. CSS-only users must set this to a url() value pointing to their own icon asset.",
-              "name": "--ogds-accordion-icon-closed"
-            },
-            {
-              "description": "Icon shown when a panel is open. Defaults to a chevron pointing up. CSS-only users must set this to a url() value pointing to their own icon asset.",
-              "name": "--ogds-accordion-icon-open"
-            }
-          ],
-          "slots": [
-            {
-              "description": "The default (only) slot for the <ogds-accordion> expects one or more plain HTML <details> elements.",
-              "name": ""
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "useListSemantics",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "use-list-semantics"
-            },
-            {
-              "kind": "field",
-              "name": "headingLevel",
-              "type": {
-                "text": "number"
-              },
-              "default": "0",
-              "attribute": "heading-level"
-            },
-            {
-              "kind": "field",
-              "name": "detailsChildren",
-              "type": {
-                "text": "HTMLCollectionOf<HTMLDetailsElement> | undefined"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "childRoles",
-              "type": {
-                "text": "Map<HTMLDetailsElement, Set<string>>"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "getDetailsChildren"
-            },
-            {
-              "kind": "method",
-              "name": "addListSemantics"
-            },
-            {
-              "kind": "method",
-              "name": "addHeadingSemantics"
-            },
-            {
-              "kind": "method",
-              "name": "applyChildRoles"
-            }
-          ],
-          "attributes": [
-            {
-              "type": {
-                "text": "boolean"
-              },
-              "description": "Adds `role=\"list\"` to the component and `role=\"listitem\"` to each `<details>` child, conveying the accordion as a list to assistive technologies. Mutually exclusive with `heading-level`.",
-              "name": "use-list-semantics",
-              "default": "false",
-              "fieldName": "useListSemantics",
-              "propName": "useListSemantics"
-            },
-            {
-              "type": {
-                "text": "number"
-              },
-              "description": "Sets a heading level for each accordion panel by adding `role=\"heading\"` and the corresponding `aria-level` to each `<summary>` element. Has no effect when set to `0` (the default). Mutually exclusive with `use-list-semantics`.",
-              "name": "heading-level",
-              "default": "0",
-              "fieldName": "headingLevel",
-              "propName": "headingLevel"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "ogds-accordion",
-          "customElement": true,
-          "summary": "The ogds-accordion component.\n\nApply these classes to `<ogds-accordion>` to enable variants:\n- `bordered` — adds a border to expanded content\n- `with-icon` — shows a chevron icon on each summary\n- `with-icon plus` — uses plus/minus icons instead of chevrons\n- `with-icon right` — aligns the icon to the right"
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "OgdsAccordion",
-          "declaration": {
-            "name": "OgdsAccordion",
-            "module": "src/components/ogds-accordion/index.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/usa-header/index.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "UsaHeader",
-          "members": [],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "UsaHeader",
-          "declaration": {
-            "name": "UsaHeader",
-            "module": "src/components/usa-header/index.ts"
           }
         }
       ]
@@ -522,6 +352,157 @@
           "declaration": {
             "name": "OgdsBanner",
             "module": "src/components/ogds-banner/index.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/ogds-accordion/index.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "OgdsAccordion",
+          "cssProperties": [
+            {
+              "description": "Border used in the bordered variant.",
+              "name": "--ogds-accordion-border"
+            },
+            {
+              "description": "Padding for the expanded content area.",
+              "name": "--ogds-accordion-content-padding"
+            },
+            {
+              "description": "Icon shown when a panel is closed. Defaults to a chevron pointing down. CSS-only users must set this to a url() value pointing to their own icon asset.",
+              "name": "--ogds-accordion-icon-closed"
+            },
+            {
+              "description": "Icon shown when a panel is open. Defaults to a chevron pointing up. CSS-only users must set this to a url() value pointing to their own icon asset.",
+              "name": "--ogds-accordion-icon-open"
+            }
+          ],
+          "slots": [
+            {
+              "description": "The default (only) slot for the <ogds-accordion> expects one or more plain HTML <details> elements.",
+              "name": ""
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "useListSemantics",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "use-list-semantics"
+            },
+            {
+              "kind": "field",
+              "name": "headingLevel",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "attribute": "heading-level"
+            },
+            {
+              "kind": "field",
+              "name": "detailsChildren",
+              "type": {
+                "text": "HTMLCollectionOf<HTMLDetailsElement> | undefined"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "childRoles",
+              "type": {
+                "text": "Map<HTMLDetailsElement, Set<string>>"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "getDetailsChildren"
+            },
+            {
+              "kind": "method",
+              "name": "addListSemantics"
+            },
+            {
+              "kind": "method",
+              "name": "addHeadingSemantics"
+            },
+            {
+              "kind": "method",
+              "name": "applyChildRoles"
+            }
+          ],
+          "attributes": [
+            {
+              "type": {
+                "text": "boolean"
+              },
+              "description": "Adds `role=\"list\"` to the component and `role=\"listitem\"` to each `<details>` child, conveying the accordion as a list to assistive technologies. Mutually exclusive with `heading-level`.",
+              "name": "use-list-semantics",
+              "default": "false",
+              "fieldName": "useListSemantics",
+              "propName": "useListSemantics"
+            },
+            {
+              "type": {
+                "text": "number"
+              },
+              "description": "Sets a heading level for each accordion panel by adding `role=\"heading\"` and the corresponding `aria-level` to each `<summary>` element. Has no effect when set to `0` (the default). Mutually exclusive with `use-list-semantics`.",
+              "name": "heading-level",
+              "default": "0",
+              "fieldName": "headingLevel",
+              "propName": "headingLevel"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "ogds-accordion",
+          "customElement": true,
+          "summary": "The ogds-accordion component.\n\nApply these classes to `<ogds-accordion>` to enable variants:\n- `bordered` — adds a border to expanded content\n- `with-icon` — shows a chevron icon on each summary\n- `with-icon plus` — uses plus/minus icons instead of chevrons\n- `with-icon right` — aligns the icon to the right"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "OgdsAccordion",
+          "declaration": {
+            "name": "OgdsAccordion",
+            "module": "src/components/ogds-accordion/index.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/usa-header/index.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "UsaHeader",
+          "members": [],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "UsaHeader",
+          "declaration": {
+            "name": "UsaHeader",
+            "module": "src/components/usa-header/index.ts"
           }
         }
       ]

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -27,6 +27,118 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/ogds-accordion-toggle/index.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "OgdsAccordionToggle",
+          "cssParts": [
+            {
+              "description": "The toggle button.",
+              "name": "button"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "controls",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "attribute": "controls"
+            },
+            {
+              "kind": "field",
+              "name": "expandLabel",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"Expand All\"",
+              "attribute": "expand-label"
+            },
+            {
+              "kind": "field",
+              "name": "collapseLabel",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"Collapse All\"",
+              "attribute": "collapse-label"
+            },
+            {
+              "kind": "field",
+              "name": "_anyOpen",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false"
+            },
+            {
+              "kind": "method",
+              "name": "checkOpen"
+            },
+            {
+              "kind": "method",
+              "name": "toggleAll"
+            }
+          ],
+          "attributes": [
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "The `id` of the `<ogds-accordion>` to control. Required.",
+              "name": "controls",
+              "default": "\"\"",
+              "fieldName": "controls",
+              "propName": "controls"
+            },
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "Button label when all panels are collapsed. Defaults to \"Expand All\".",
+              "name": "expand-label",
+              "default": "\"Expand All\"",
+              "fieldName": "expandLabel",
+              "propName": "expandLabel"
+            },
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "Button label when one or more panels are open. Defaults to \"Collapse All\".",
+              "name": "collapse-label",
+              "default": "\"Collapse All\"",
+              "fieldName": "collapseLabel",
+              "propName": "collapseLabel"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "ogds-accordion-toggle",
+          "customElement": true,
+          "summary": "A button that expands or collapses all panels in an associated `<ogds-accordion>`."
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "OgdsAccordionToggle",
+          "declaration": {
+            "name": "OgdsAccordionToggle",
+            "module": "src/components/ogds-accordion-toggle/index.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/ogds-accordion/index.ts",
       "declarations": [
         {
@@ -151,112 +263,27 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/ogds-accordion-toggle/index.ts",
+      "path": "src/components/usa-header/index.ts",
       "declarations": [
         {
           "kind": "class",
           "description": "",
-          "name": "OgdsAccordionToggle",
-          "cssParts": [
-            {
-              "description": "The toggle button.",
-              "name": "button"
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "controls",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\"",
-              "attribute": "controls"
-            },
-            {
-              "kind": "field",
-              "name": "expandLabel",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"Expand All\"",
-              "attribute": "expand-label"
-            },
-            {
-              "kind": "field",
-              "name": "collapseLabel",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"Collapse All\"",
-              "attribute": "collapse-label"
-            },
-            {
-              "kind": "field",
-              "name": "_anyOpen",
-              "type": {
-                "text": "boolean"
-              },
-              "privacy": "private",
-              "default": "false"
-            },
-            {
-              "kind": "method",
-              "name": "checkOpen"
-            },
-            {
-              "kind": "method",
-              "name": "toggleAll"
-            }
-          ],
-          "attributes": [
-            {
-              "type": {
-                "text": "string"
-              },
-              "description": "The `id` of the `<ogds-accordion>` to control. Required.",
-              "name": "controls",
-              "default": "\"\"",
-              "fieldName": "controls",
-              "propName": "controls"
-            },
-            {
-              "type": {
-                "text": "string"
-              },
-              "description": "Button label when all panels are collapsed. Defaults to \"Expand All\".",
-              "name": "expand-label",
-              "default": "\"Expand All\"",
-              "fieldName": "expandLabel",
-              "propName": "expandLabel"
-            },
-            {
-              "type": {
-                "text": "string"
-              },
-              "description": "Button label when one or more panels are open. Defaults to \"Collapse All\".",
-              "name": "collapse-label",
-              "default": "\"Collapse All\"",
-              "fieldName": "collapseLabel",
-              "propName": "collapseLabel"
-            }
-          ],
+          "name": "UsaHeader",
+          "members": [],
           "superclass": {
             "name": "LitElement",
             "package": "lit"
           },
-          "tagName": "ogds-accordion-toggle",
-          "customElement": true,
-          "summary": "A button that expands or collapses all panels in an associated `<ogds-accordion>`."
+          "customElement": true
         }
       ],
       "exports": [
         {
           "kind": "js",
-          "name": "OgdsAccordionToggle",
+          "name": "UsaHeader",
           "declaration": {
-            "name": "OgdsAccordionToggle",
-            "module": "src/components/ogds-accordion-toggle/index.ts"
+            "name": "UsaHeader",
+            "module": "src/components/usa-header/index.ts"
           }
         }
       ]
@@ -495,33 +522,6 @@
           "declaration": {
             "name": "OgdsBanner",
             "module": "src/components/ogds-banner/index.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/usa-header/index.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "UsaHeader",
-          "members": [],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "UsaHeader",
-          "declaration": {
-            "name": "UsaHeader",
-            "module": "src/components/usa-header/index.ts"
           }
         }
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ogds/elements",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ogds/elements",
-      "version": "1.0.0-alpha.6",
+      "version": "1.0.0-alpha.7",
       "dependencies": {
         "@ogds/tokens": "^1.0.0-alpha.2",
         "@uswds/uswds": "^3.13.0",
@@ -3180,9 +3180,9 @@
       }
     },
     "node_modules/@ogds/tokens": {
-      "version": "1.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@ogds/tokens/-/tokens-1.0.0-alpha.2.tgz",
-      "integrity": "sha512-pLDf3ooinQQNgrjodxvSFj/NTgTqpAOQSG4nqidR62POvlyDXOErbLXBDVymOrAGDRHpECtAq4NG3KoXrKBIqA=="
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@ogds/tokens/-/tokens-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-O9GKyhPZe0VEKlh/DyGqJ1eIm2ww/PVFmRwN8HdCgS2890cE3G00sxDctohnSWDzBbaphs8ISYPZTAjEGTZ3Hw=="
     },
     "node_modules/@oxc-resolver/binding-android-arm-eabi": {
       "version": "11.13.1",

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 import { OgdsBanner } from "./ogds-banner";
 import { OgdsAccordion } from "./ogds-accordion";
+import { OgdsAccordionToggle } from "./ogds-accordion-toggle";
 
-export { OgdsBanner, OgdsAccordion };
+export { OgdsBanner, OgdsAccordion, OgdsAccordionToggle };

--- a/src/components/ogds-accordion-toggle/docs.mdx
+++ b/src/components/ogds-accordion-toggle/docs.mdx
@@ -1,0 +1,54 @@
+import { Meta, Title, Primary, Stories } from "@storybook/addon-docs/blocks";
+
+<Meta isTemplate />
+
+<Title />
+
+The accordion toggle provides a single button to expand or collapse all panels in an associated `<ogds-accordion>`.
+
+---
+
+## Default
+
+<Primary />
+
+---
+
+## Variations
+
+<Stories />
+
+## Guidance
+
+### When to use the accordion toggle
+
+_When accordions have many items._ The toggle is most useful when an accordion has more than two or three items, where expanding each individually would be tedious and users may want to scan all of the content at once.
+
+_For cross-browser in-page search._ `Cmd-/Ctrl-F` will find content in collapsed accordion sections and open the relevant sections in Chrome and Chromium-based browsers. However, as of now this behavior is limited to only those browsers (see ["Auto-opens when matched via page search"](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details#browser_compatibility)). Adding the toggle button will allow users to search all of the accordion content in any browser.
+
+_To support users looking to print the page content._ Let users display all of the page's content so it can be printed.
+
+### Usage
+
+Connect the toggle to an accordion using the `controls` attribute, which must match the `id` of the target `<ogds-accordion>`:
+
+```html
+<ogds-accordion-toggle controls="my-accordion"></ogds-accordion-toggle>
+<ogds-accordion id="my-accordion">
+  <details>
+    <summary>Item One</summary>
+    <p>Content</p>
+  </details>
+</ogds-accordion>
+```
+
+### Customizing labels
+
+By default, the button reads "Expand All" when all panels are collapsed and "Collapse All" when any panel is open. Override these with the `expand-label` and `collapse-label` named slots:
+
+```html
+<ogds-accordion-toggle controls="my-accordion">
+  <span slot="expand-label">Show All</span>
+  <span slot="collapse-label">Hide All</span>
+</ogds-accordion-toggle>
+```

--- a/src/components/ogds-accordion-toggle/index.ts
+++ b/src/components/ogds-accordion-toggle/index.ts
@@ -1,0 +1,91 @@
+import { LitElement, html } from "lit";
+import { adoptTokenStyles } from "../../core/token-styles";
+import { defineCustomElement } from "../../utils";
+
+import { property, state } from "lit/decorators.js";
+import styles from "./ogds-accordion-toggle.css";
+
+/**
+ * @summary A button that expands or collapses all panels in an associated `<ogds-accordion>`.
+ *
+ * @attribute {string} controls - The `id` of the `<ogds-accordion>` to control. Required.
+ * @attribute {string} expand-label - Button label when all panels are collapsed. Defaults to "Expand All".
+ * @attribute {string} collapse-label - Button label when one or more panels are open. Defaults to "Collapse All".
+ *
+ * @csspart button - The toggle button.
+ *
+ * @element ogds-accordion-toggle
+ */
+export class OgdsAccordionToggle extends LitElement {
+  /** @ignore */
+  private static _sheet: CSSStyleSheet | null = null;
+
+  @property({ type: String, attribute: "controls" })
+  controls = "";
+
+  @property({ type: String, attribute: "expand-label" })
+  expandLabel = "Expand All";
+
+  @property({ type: String, attribute: "collapse-label" })
+  collapseLabel = "Collapse All";
+
+  @state()
+  private _anyOpen = false;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    adoptTokenStyles();
+    if (!OgdsAccordionToggle._sheet) {
+      OgdsAccordionToggle._sheet = new CSSStyleSheet();
+      OgdsAccordionToggle._sheet.replaceSync(styles.cssText);
+      document.adoptedStyleSheets = [
+        ...document.adoptedStyleSheets,
+        OgdsAccordionToggle._sheet,
+      ];
+    }
+    if (this.controls == "") {
+      console.error(
+        "<ogds-accordion-toggle>: Component must have a controls attribute with the ID" +
+          "of an <ogds-accordion> component",
+      );
+      return;
+    }
+    this._anyOpen = this.checkOpen();
+  }
+
+  checkOpen() {
+    const accordionEl = document.getElementById(this.controls);
+    const openDetails = accordionEl?.querySelector("details[open]");
+    return !!openDetails;
+  }
+
+  toggleAll() {
+    const accordionEl = document.getElementById(this.controls);
+    if (!accordionEl) {
+      console.error(
+        "<ogds-accordion-toggle>: Unable to get an accordion component with the ID" +
+          " specfied in the controls attribute",
+      );
+      return;
+    }
+
+    const detailsEls = Array.from(accordionEl.getElementsByTagName("details"));
+    const anyOpen = detailsEls.some((d) => d.hasAttribute("open"));
+    if (!anyOpen) {
+      detailsEls.forEach((d) => d.toggleAttribute("open", true));
+    } else {
+      detailsEls.forEach((d) => d.toggleAttribute("open", false));
+    }
+    this._anyOpen = !anyOpen;
+  }
+
+  protected override render(): unknown {
+    return html`
+      <button @click="${this.toggleAll}" part="button">
+        ${this._anyOpen ? this.collapseLabel : this.expandLabel}
+      </button>
+    `;
+  }
+}
+
+defineCustomElement("ogds-accordion-toggle", OgdsAccordionToggle);

--- a/src/components/ogds-accordion-toggle/index.ts
+++ b/src/components/ogds-accordion-toggle/index.ts
@@ -96,7 +96,9 @@ export class OgdsAccordionToggle extends LitElement {
     return html`
       <button @click="${this.toggleAll}" part="button">
         <slot name="expand-label" ?hidden="${this._anyOpen}">Expand All</slot>
-        <slot name="collapse-label" ?hidden="${!this._anyOpen}">Collapse All</slot>
+        <slot name="collapse-label" ?hidden="${!this._anyOpen}"
+          >Collapse All</slot
+        >
       </button>
     `;
   }

--- a/src/components/ogds-accordion-toggle/index.ts
+++ b/src/components/ogds-accordion-toggle/index.ts
@@ -9,8 +9,9 @@ import styles from "./ogds-accordion-toggle.css";
  * @summary A button that expands or collapses all panels in an associated `<ogds-accordion>`.
  *
  * @attribute {string} controls - The `id` of the `<ogds-accordion>` to control. Required.
- * @attribute {string} expand-label - Button label when all panels are collapsed. Defaults to "Expand All".
- * @attribute {string} collapse-label - Button label when one or more panels are open. Defaults to "Collapse All".
+ *
+ * @slot expand-label - Button label when all panels are collapsed. Defaults to "Expand All".
+ * @slot collapse-label - Button label when one or more panels are open. Defaults to "Collapse All".
  *
  * @csspart button - The toggle button.
  *
@@ -23,14 +24,10 @@ export class OgdsAccordionToggle extends LitElement {
   @property({ type: String, attribute: "controls" })
   controls = "";
 
-  @property({ type: String, attribute: "expand-label" })
-  expandLabel = "Expand All";
-
-  @property({ type: String, attribute: "collapse-label" })
-  collapseLabel = "Collapse All";
-
   @state()
   private _anyOpen = false;
+
+  private _observer: MutationObserver | null = null;
 
   override connectedCallback() {
     super.connectedCallback();
@@ -51,6 +48,22 @@ export class OgdsAccordionToggle extends LitElement {
       return;
     }
     this._anyOpen = this.checkOpen();
+    this._observer = new MutationObserver(() => {
+      this._anyOpen = this.checkOpen();
+    });
+    const accordionEl = document.getElementById(this.controls);
+    if (accordionEl) {
+      this._observer.observe(accordionEl, {
+        subtree: true,
+        attributeFilter: ["open"],
+      });
+    }
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this._observer?.disconnect();
+    this._observer = null;
   }
 
   checkOpen() {
@@ -82,7 +95,8 @@ export class OgdsAccordionToggle extends LitElement {
   protected override render(): unknown {
     return html`
       <button @click="${this.toggleAll}" part="button">
-        ${this._anyOpen ? this.collapseLabel : this.expandLabel}
+        <slot name="expand-label" ?hidden="${this._anyOpen}">Expand All</slot>
+        <slot name="collapse-label" ?hidden="${!this._anyOpen}">Collapse All</slot>
       </button>
     `;
   }

--- a/src/components/ogds-accordion-toggle/ogds-accordion-toggle.css
+++ b/src/components/ogds-accordion-toggle/ogds-accordion-toggle.css
@@ -1,0 +1,31 @@
+@layer ogds.components;
+
+@layer ogds.components {
+  ogds-accordion-toggle::part(button) {
+    appearance: none;
+    background-color: var(--ogds-theme-button-fill-color);
+    border-color: transparent;
+    border-radius: var(--ogds-theme-button-border-radius);
+    border-width: var(--ogds-theme-button-stroke-width);
+    color: var(--ogds-theme-button-text-color);
+    cursor: pointer;
+    font-family: var(--ogds-theme-button-font-family);
+    font-size: var(--ogds-theme-type-scale-md);
+    font-weight: 700;
+    padding: var(--ogds-spacing-105) var(--ogds-spacing-205);
+
+    &:hover {
+      background-color: color-mix(
+        in srgb,
+        var(--ogds-theme-button-fill-color),
+        black 20%
+      );
+    }
+
+    &:focus {
+      /* :not([disabled]) doesn't seem to be supported on shadow parts */
+      outline: rgb(36 145 255) solid 0.25rem;
+      outline-offset: 0.25rem;
+    }
+  }
+}

--- a/src/components/ogds-accordion-toggle/ogds-accordion-toggle.spec.ts
+++ b/src/components/ogds-accordion-toggle/ogds-accordion-toggle.spec.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("./ogds-accordion-toggle.css", () => ({ default: { cssText: "" } }));
+vi.mock("../../core/token-styles", () => ({ adoptTokenStyles: vi.fn() }));
+
+import { OgdsAccordionToggle } from "./index";
+
+function mountPair({
+  accordionId = "test-accordion",
+  openItems = false,
+  expandLabel,
+  collapseLabel,
+}: {
+  accordionId?: string;
+  openItems?: boolean;
+  expandLabel?: string;
+  collapseLabel?: string;
+} = {}): OgdsAccordionToggle {
+  const accordion = document.createElement("div");
+  accordion.id = accordionId;
+  accordion.innerHTML = `
+    <details${openItems ? " open" : ""}><summary>One</summary></details>
+    <details${openItems ? " open" : ""}><summary>Two</summary></details>
+  `;
+  document.body.appendChild(accordion);
+
+  const toggle = document.createElement(
+    "ogds-accordion-toggle",
+  ) as OgdsAccordionToggle;
+  toggle.setAttribute("controls", accordionId);
+  if (expandLabel) {
+    const span = document.createElement("span");
+    span.slot = "expand-label";
+    span.textContent = expandLabel;
+    toggle.appendChild(span);
+  }
+  if (collapseLabel) {
+    const span = document.createElement("span");
+    span.slot = "collapse-label";
+    span.textContent = collapseLabel;
+    toggle.appendChild(span);
+  }
+  document.body.appendChild(toggle);
+  return toggle;
+}
+
+function getButton(toggle: OgdsAccordionToggle): HTMLButtonElement {
+  return toggle.shadowRoot!.querySelector("button") as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  document.adoptedStyleSheets = [];
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function getExpandSlot(toggle: OgdsAccordionToggle): HTMLSlotElement {
+  return toggle.shadowRoot!.querySelector(
+    'slot[name="expand-label"]',
+  ) as HTMLSlotElement;
+}
+
+function getCollapseSlot(toggle: OgdsAccordionToggle): HTMLSlotElement {
+  return toggle.shadowRoot!.querySelector(
+    'slot[name="collapse-label"]',
+  ) as HTMLSlotElement;
+}
+
+describe("rendering", () => {
+  it("renders with the expand slot visible and fallback text 'Expand All' by default", async () => {
+    const toggle = mountPair();
+    await toggle.updateComplete;
+    expect(getExpandSlot(toggle).hasAttribute("hidden")).toBe(false);
+    expect(getExpandSlot(toggle).textContent?.trim()).toBe("Expand All");
+    expect(getCollapseSlot(toggle).hasAttribute("hidden")).toBe(true);
+  });
+
+  it("renders with custom slotted expand label content", async () => {
+    const toggle = mountPair({
+      expandLabel: "Open All",
+      collapseLabel: "Close All",
+    });
+    await toggle.updateComplete;
+    expect(toggle.querySelector('[slot="expand-label"]')?.textContent).toBe(
+      "Open All",
+    );
+    expect(toggle.querySelector('[slot="collapse-label"]')?.textContent).toBe(
+      "Close All",
+    );
+  });
+});
+
+describe("MutationObserver sync", () => {
+  it("switches to collapse slot when a panel is opened manually", async () => {
+    const toggle = mountPair();
+    await toggle.updateComplete;
+    expect(getExpandSlot(toggle).hasAttribute("hidden")).toBe(false);
+
+    const details = document.querySelector("details")!;
+    details.setAttribute("open", "");
+    await Promise.resolve(); // flush MutationObserver callback
+    await toggle.updateComplete;
+
+    expect(getCollapseSlot(toggle).hasAttribute("hidden")).toBe(false);
+    expect(getExpandSlot(toggle).hasAttribute("hidden")).toBe(true);
+  });
+
+  it("switches to expand slot when all panels are closed manually", async () => {
+    const toggle = mountPair({ openItems: true });
+    await toggle.updateComplete;
+    expect(getCollapseSlot(toggle).hasAttribute("hidden")).toBe(false);
+
+    document
+      .querySelectorAll("details")
+      .forEach((d) => d.removeAttribute("open"));
+    await Promise.resolve(); // flush MutationObserver callback
+    await toggle.updateComplete;
+
+    expect(getExpandSlot(toggle).hasAttribute("hidden")).toBe(false);
+    expect(getCollapseSlot(toggle).hasAttribute("hidden")).toBe(true);
+  });
+});
+
+describe("toggleAll", () => {
+  it("opens all details when none are open", async () => {
+    const toggle = mountPair();
+    await toggle.updateComplete;
+    getButton(toggle).click();
+    await toggle.updateComplete;
+    document.querySelectorAll("details").forEach((d) => {
+      expect(d.hasAttribute("open")).toBe(true);
+    });
+  });
+
+  it("shows the collapse slot and hides the expand slot after expanding all", async () => {
+    const toggle = mountPair();
+    await toggle.updateComplete;
+    getButton(toggle).click();
+    await toggle.updateComplete;
+    expect(getCollapseSlot(toggle).hasAttribute("hidden")).toBe(false);
+    expect(getExpandSlot(toggle).hasAttribute("hidden")).toBe(true);
+  });
+
+  it("closes all details when all are open", async () => {
+    const toggle = mountPair();
+    await toggle.updateComplete;
+    getButton(toggle).click();
+    await toggle.updateComplete;
+    getButton(toggle).click();
+    await toggle.updateComplete;
+    document.querySelectorAll("details").forEach((d) => {
+      expect(d.hasAttribute("open")).toBe(false);
+    });
+  });
+
+  it("shows the expand slot and hides the collapse slot after collapsing all", async () => {
+    const toggle = mountPair();
+    await toggle.updateComplete;
+    getButton(toggle).click();
+    await toggle.updateComplete;
+    getButton(toggle).click();
+    await toggle.updateComplete;
+    expect(getExpandSlot(toggle).hasAttribute("hidden")).toBe(false);
+    expect(getCollapseSlot(toggle).hasAttribute("hidden")).toBe(true);
+  });
+
+  it("logs an error when the target accordion is not found", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    document.body.innerHTML = `<ogds-accordion-toggle controls="nonexistent"></ogds-accordion-toggle>`;
+    const toggle = document.body.querySelector(
+      "ogds-accordion-toggle",
+    ) as OgdsAccordionToggle;
+    await toggle.updateComplete;
+    toggle.toggleAll();
+    expect(errorSpy).toHaveBeenCalledOnce();
+    errorSpy.mockRestore();
+  });
+});
+
+describe("checkOpen", () => {
+  it("returns false when no details are open", async () => {
+    const toggle = mountPair();
+    await toggle.updateComplete;
+    expect(toggle.checkOpen()).toBe(false);
+  });
+
+  it("returns true when at least one details is open", async () => {
+    const toggle = mountPair({ openItems: true });
+    await toggle.updateComplete;
+    expect(toggle.checkOpen()).toBe(true);
+  });
+});
+
+describe("missing controls attribute", () => {
+  it("logs a console error when controls is not set", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    document.body.innerHTML = `<ogds-accordion-toggle></ogds-accordion-toggle>`;
+    const toggle = document.body.querySelector(
+      "ogds-accordion-toggle",
+    ) as OgdsAccordionToggle;
+    await toggle.updateComplete;
+    expect(errorSpy).toHaveBeenCalledOnce();
+    errorSpy.mockRestore();
+  });
+});
+
+describe("stylesheet adoption", () => {
+  beforeEach(() => {
+    (OgdsAccordionToggle as any)._sheet = null;
+    document.adoptedStyleSheets = [];
+  });
+
+  it("adds a stylesheet to document.adoptedStyleSheets on first mount", async () => {
+    const toggle = mountPair();
+    await toggle.updateComplete;
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+  });
+
+  it("does not add the stylesheet more than once when multiple toggles are mounted", async () => {
+    const toggle1 = mountPair({ accordionId: "acc1" });
+    const toggle2 = mountPair({ accordionId: "acc2" });
+    await Promise.all([toggle1.updateComplete, toggle2.updateComplete]);
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+  });
+});

--- a/src/components/ogds-accordion-toggle/ogds-accordion-toggle.stories.ts
+++ b/src/components/ogds-accordion-toggle/ogds-accordion-toggle.stories.ts
@@ -1,0 +1,95 @@
+import { html } from "lit";
+import "./index";
+import "../ogds-accordion/index";
+import ComponentDocs from "./docs.mdx";
+import { expect, userEvent, waitFor } from "storybook/test";
+import { within } from "shadow-dom-testing-library";
+
+const items = html`
+  <details>
+    <summary>First Amendment</summary>
+    <p>
+      Congress shall make no law respecting an establishment of religion, or
+      prohibiting the free exercise thereof; or abridging the freedom of speech,
+      or of the press; or the right of the people peaceably to assemble, and to
+      petition the Government for a redress of grievances.
+    </p>
+  </details>
+  <details>
+    <summary>Second Amendment</summary>
+    <p>
+      A well regulated Militia, being necessary to the security of a free State,
+      the right of the people to keep and bear Arms, shall not be infringed.
+    </p>
+  </details>
+  <details>
+    <summary>Third Amendment</summary>
+    <p>
+      No Soldier shall, in time of peace be quartered in any house, without the
+      consent of the Owner, nor in time of war, but in a manner to be prescribed
+      by law.
+    </p>
+  </details>
+`;
+
+export default {
+  title: "Components/Accordion Toggle",
+  component: "ogds-accordion-toggle",
+  tags: ["alpha"],
+  parameters: {
+    docs: {
+      page: ComponentDocs,
+    },
+  },
+};
+
+export const Default = {
+  render: () => html`
+    <ogds-accordion-toggle
+      controls="accordion-toggle-default"
+    ></ogds-accordion-toggle>
+    <ogds-accordion id="accordion-toggle-default">${items}</ogds-accordion>
+  `,
+};
+
+export const CustomLabels = {
+  render: () => html`
+    <ogds-accordion-toggle controls="accordion-toggle-custom">
+      <span slot="expand-label">Show All</span>
+      <span slot="collapse-label">Hide All</span>
+    </ogds-accordion-toggle>
+    <ogds-accordion id="accordion-toggle-custom">${items}</ogds-accordion>
+  `,
+};
+
+export const ToggleTest = {
+  parameters: {
+    docs: {
+      disable: true,
+    },
+  },
+  render: () => html`
+    <ogds-accordion-toggle
+      controls="accordion-toggle-test"
+    ></ogds-accordion-toggle>
+    <ogds-accordion id="accordion-toggle-test">${items}</ogds-accordion>
+  `,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByShadowRole("button");
+
+    await userEvent.click(button);
+    await waitFor(() => {
+      canvasElement.querySelectorAll("details").forEach((d) => {
+        expect(d).toHaveAttribute("open");
+      });
+    });
+
+    await userEvent.click(button);
+    await waitFor(() => {
+      canvasElement.querySelectorAll("details").forEach((d) => {
+        expect(d).not.toHaveAttribute("open");
+      });
+    });
+  },
+};

--- a/src/core/token-styles.ts
+++ b/src/core/token-styles.ts
@@ -2,6 +2,7 @@ import colorTokens from "@ogds/tokens/styles/css/colors.css";
 import spacingTokens from "@ogds/tokens/styles/css/spacing.css";
 import typographyTokens from "@ogds/tokens/styles/css/typography.css";
 import themeColorTokens from "@ogds/tokens/styles/css/theme-color.css";
+import themeComponentTokens from "@ogds/tokens/styles/css/theme-components.css";
 import themeSpacingTokens from "@ogds/tokens/styles/css/theme-spacing.css";
 import themeTypographyTokens from "@ogds/tokens/styles/css/theme-typography.css";
 
@@ -12,6 +13,7 @@ sheet.replaceSync(
     spacingTokens,
     typographyTokens,
     themeColorTokens,
+    themeComponentTokens,
     themeSpacingTokens,
     themeTypographyTokens,
   ]


### PR DESCRIPTION
# Summary

Added a new component to expand/collapse all of the sections of an associated `ogds-accordion` component.

## Problem statement

In instances where an `ogds-accordion` component has a lot of content, it can be helpful to give users a way to open/close all of the accordion sections at once—in particular, to let users `cmd-/ctrl-F` into the content in a way that works across browsers or when users may want to print the content.

## Solution

The `ogds-accordion-toggle` component is a button that can open/close all of the sections of an associated `ogds-accordion` component. If any of the accordion sections are open (no matter how they're opened), the button text will reflect that and let the user close all of the sections. Otherwise, the button opens all of the sections (and the text reflects this as well).

There is default text in the component for each state, but the component also supports setting custom text through slots so the strings can be translated (or otherwise customized).

This screen recording shows the basic interaction:

https://github.com/user-attachments/assets/4b742fa7-f821-4428-b93d-75bb822aa055

## Testing and review

The simplest way to test is by running the storybook locally.