### PR TITLE
Extract JS script from deploy-preview workflow

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -55,44 +55,5 @@ jobs:
           DEPLOYMENT_URL: ${{ steps.preview.outputs.deployment-url }}
         with:
           script: |
-            const marker = '<!-- storybook-preview -->';
-            const shortSha = context.payload.pull_request.head.sha.substring(0, 8);
-            const now = new Date().toLocaleDateString('en-US', {
-              year: 'numeric', month: 'short', day: 'numeric',
-              hour: '2-digit', minute: '2-digit',
-              timeZone: 'America/New_York'
-            });
-            const deploymentUrl = process.env.DEPLOYMENT_URL;
-            const branch = context.payload.pull_request.head.ref;
-
-            const body = [
-              marker,
-              `## Storybook Preview 👀`,
-              ``,
-              `- **Preview:** [Open Storybook PR Preview](${deploymentUrl})`,
-              `- **Branch:** \`${branch}\``,
-              `- **Latest Commit:** \`${shortSha}\``,
-              `- **Updated:** ${now} (ET)`,
-            ].join('\n');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.deleteComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-              });
-            }
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
+            const script = require('./.github/workflows/helpers/post-deploy-preview-github-comment.js');
+            await script({ github, context, core });

--- a/.github/workflows/helpers/post-deploy-preview-github-comment.js
+++ b/.github/workflows/helpers/post-deploy-preview-github-comment.js
@@ -1,0 +1,46 @@
+module.exports = async ({ github, context, core }) => {
+  const marker = "<!-- storybook-preview -->";
+  const shortSha = context.payload.pull_request.head.sha.substring(0, 8);
+  const now = new Date().toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "America/New_York",
+  });
+  const deploymentUrl = process.env.DEPLOYMENT_URL;
+  const branch = context.payload.pull_request.head.ref;
+
+  const body = [
+    marker,
+    `## Storybook Preview 👀`,
+    ``,
+    `- **Preview:** [Open Storybook PR Preview](${deploymentUrl})`,
+    `- **Branch:** \`${branch}\``,
+    `- **Latest Commit:** \`${shortSha}\``,
+    `- **Updated:** ${now} (ET)`,
+  ].join("\n");
+
+  const { data: comments } = await github.rest.issues.listComments({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: context.issue.number,
+  });
+  const existing = comments.find((c) => c.body.includes(marker));
+
+  if (existing) {
+    await github.rest.issues.deleteComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: existing.id,
+    });
+  }
+
+  await github.rest.issues.createComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: context.issue.number,
+    body,
+  });
+};


### PR DESCRIPTION
# Summary

Following up on the very cool work done in https://github.com/open-government-design-system/ogds-elements/pull/38 with a small improvement to the developer experience for folks who are interested in reading or contributing to it, by moving a JavaScript script out of the YAML file and into a separate JS file.

## Problem statement

There is a JS script in the deploy-preview workflow which is embedded in the YAML file. When developers edit that script, the developer experience is not great. Things like syntax highlighting, prettier formatting, and linting are not available. Furthermore, it's difficult to tell which interpolations are GitHub Actions style (`${{ foo }}`) and which are JavaScript style (`${ foo }`) without reading very carefully.

## Solution

Extract the JS script into a separate JS file, following the instructions here: https://github.com/actions/github-script/tree/v9.0.0#run-a-separate-file-with-an-async-function

## Testing and review

It'll be very clear if this doesn't work, because the workflow will fail when we open PRs.

I'm opening this PR from a fork, so I don't know if the workflow will actually run, so that may make it a little harder to test it.