### PR TITLE
Run ESLint in CI and pre-commit hook

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -25,3 +25,6 @@ jobs:
 
       - name: Run stylelint
         run: "npm run stylelint"
+
+      - name: Run eslint
+        run: "npm run eslint"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,4 +4,5 @@ npm run prettier:js:fix
 npm run prettier:md:fix
 npm run prettier:github:fix
 npm run stylelint:fix
+npm run eslint
 npm run test:ci

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import eslintConfigPrettierRecommended from "eslint-config-prettier";
 import vitest from "@vitest/eslint-plugin";
 
 export default [
-  { ignores: ["storybook-static/**"] },
+  { ignores: ["storybook-static/**", "examples/**"] },
   {
     ...js.configs.recommended,
     ...eslintConfigPrettierRecommended,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,18 @@ import eslintConfigPrettierRecommended from "eslint-config-prettier";
 import vitest from "@vitest/eslint-plugin";
 
 export default [
-  { ignores: ["storybook-static/**", "examples/**", "**/*.ts"] },
+  {
+    ignores: [
+      "storybook-static/**",
+      "examples/**",
+
+      // FIXME: configure ESLint for TypeScript too
+      "**/*.ts",
+
+      // FIXME: stop ignoring this file when the @eslint/css parser can handle it
+      "src/components/ogds-accordion/ogds-accordion.css",
+    ],
+  },
   {
     ...js.configs.recommended,
     ...eslintConfigPrettierRecommended,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import eslintConfigPrettierRecommended from "eslint-config-prettier";
 import vitest from "@vitest/eslint-plugin";
 
 export default [
-  { ignores: ["storybook-static/**", "examples/**"] },
+  { ignores: ["storybook-static/**", "examples/**", "**/*.ts"] },
   {
     ...js.configs.recommended,
     ...eslintConfigPrettierRecommended,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ export default [
     rules: {
       ...css.configs.recommended.rules,
       "css/use-baseline": ["warn", { available: "widely" }],
+      "css/no-invalid-properties": ["error", { allowUnknownVariables: true }],
     },
   },
   ...storybook.configs["flat/recommended"],

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "build": "tsc -p ./config/tsconfig.json && vite build --config ./config/vite.config.ts && npm run manifest:build",
     "build:watch": "vite build --config ./config/vite.config.ts --watch",
     "dev": "vite --config ./config/vite.config.ts",
+    "eslint": "eslint .",
     "fix-permissions": "sudo chown -R $(id -u):$(id -g) .",
     "pages": "npm run storybook:build && cp -r storybook-static _site",
     "playwright:install": "playwright install --with-deps",


### PR DESCRIPTION
# Summary

This project already has ESLint set up, but it's presently broken: running it produces some errors.

Let's run it in CI and the pre-commit hook so that we know that it's actually working and we're getting value from it.

Alternatively, we could remove it.

This PR runs it in CI and makes a few tweaks to get it running without error:

- Ignore TS files for now (otherwise we fail with a parsing error)
- Ignore the examples directory (otherwise we fail with an error about `globals` not being installed)
- Ignore a recently-introduced CSS file which uses some modern CSS features that the `@eslint/css` parser can't understand
- Configure an existing rule to not fail when it encounters unknown css variables

## Testing and review

- You can try running `npm run eslint` locally and confirm it fails on main and passes on this branch
- You can provide feedback on the configuration changes to get everything green