### PR TITLE
Bump playwright to 1.58.2

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.55.0-noble
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     env:
       HOME: /root
     steps:

--- a/.github/workflows/update-playwright-snapshots.yml
+++ b/.github/workflows/update-playwright-snapshots.yml
@@ -14,7 +14,7 @@ jobs:
   screenshots:
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.55.0-noble
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     env:
       HOME: /root
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use official Playwright image with all browsers; version should match CI
-FROM mcr.microsoft.com/playwright:v1.55.0-noble
+FROM mcr.microsoft.com/playwright:v1.58.2-noble
 
 # Install system packages needed for development (if any)
 # RUN apt-get update && apt-get install -y <your-packages>


### PR DESCRIPTION
# Summary

Consistently reference the same version of Playwright everywhere.

We already updated it in package.json, but we forgot to update these other references. It's good to keep them in sync.

## Related issue

Related to #78 -- this manually resolves the issue on main, but doesn't prevent the same issue from recurring.

## Problem statement

We specify the version of [Playwright](https://playwright.dev/) in several places. They should all match but they don't.

## Solution

Make them match, preferring the newer version

## Testing and review

I'm optimistic that the automated testing should be sufficient to test this one