### PR TITLE
Fix Playwright failure comment

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,6 +30,7 @@ jobs:
         run: npm run playwright:test
 
       - uses: actions/upload-artifact@v7
+        id: artifact-upload
         if: ${{ !cancelled() }}
         with:
           name: playwright-report


### PR DESCRIPTION

# Summary

Fix the Playwright failure comment so that its link to the useful metadata artifact actually works.

## Related issue

Closes #79

## Problem statement

When Playwright tests run and fail in CI, they upload a useful artifact to GitHub, and then leave a comment on the PR with the link where someone can download the artifact. But the link doesn't work.

## Solution

The problem is that we're trying to reference the earlier step by name, but we haven't given it a name. I'm hopeful that just giving it a name will make everything Just Work. 

## Testing and review

I haven't actually tested this yet... I'm going to temporarily cherry-pick the commit over to the branch for https://github.com/open-government-design-system/ogds-elements/pull/43 and see if the comment shows up properly.