### PR TITLE
Fix update-playwright-snapshots workflow

### DIFF
--- a/.github/workflows/update-playwright-snapshots.yml
+++ b/.github/workflows/update-playwright-snapshots.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm run playwright:install
 
       - name: Run Playwright to generate screenshots
-        run: npm run playwright:update-snapshots
+        run: npm run playwright:update-screenshots
 
       - name: Upload new screenshots
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
# Summary

We have a GitHub Actions workflow which regenerates Playwright screenshots/snapshots. The workflow runs an npm script. I tried running it but it [failed](https://github.com/open-government-design-system/ogds-elements/actions/runs/27144326966), because the script it tries to run does not exist. Perhaps it got renamed at some point.

## Problem statement

Some of the Playwright tests compare the code against some pre-generated screenshots to make sure that we don't have unexpected visual regressions. Sometimes we ant to regenerate those screenshots when we _do_ expect to have visual changes. We have a GitHub actions workflow which can generate those, but it doesn't currently work.

## Solution

Update the workflow to call the script by its current name.

## Testing and review

- [x] I can try running it based on this branch and see if it works... https://github.com/open-government-design-system/ogds-elements/actions/runs/27145655202