### PR TITLE
Configure allowScripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,5 +120,15 @@
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.59.0"
+  },
+  "allowScripts": {
+    "esbuild@0.25.9": true,
+    "esbuild@0.27.3": true,
+    "@parcel/watcher@2.5.1": true,
+    "@swc/core@1.13.5": true,
+    "fsevents@2.3.3": true,
+    "fsevents@2.3.2": true,
+    "unrs-resolver@1.11.1": true,
+    "rs-module-lexer@2.6.0": true
   }
 }


### PR DESCRIPTION
# Summary

In npm 11.16.0+, npm starts to emit a warning when a dependency has a script which has not been explicitly allowed. For now it's just a warning, but my understanding is that it will turn into an error in npm 12
(https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/).

This commit explicitly allows all of the scripts, which makes the warning go away.

I got the list by running:

```
npm approve-scripts --allow-scripts-pending
```

Important caveat: I haven't scrutinized each of these scripts in any way.

