### PR TITLE
Update Storybook comment rather than replacing it

### DIFF
--- a/.github/workflows/helpers/post-deploy-preview-github-comment.js
+++ b/.github/workflows/helpers/post-deploy-preview-github-comment.js
@@ -30,17 +30,18 @@ export async function postComment({ github, context, core }) {
   const existing = comments.find((c) => c.body.includes(marker));
 
   if (existing) {
-    await github.rest.issues.deleteComment({
+    await github.rest.issues.updateComment({
       owner: context.repo.owner,
       repo: context.repo.repo,
       comment_id: existing.id,
+      body,
+    });
+  } else {
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.issue.number,
+      body,
     });
   }
-
-  await github.rest.issues.createComment({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    issue_number: context.issue.number,
-    body,
-  });
 }


### PR DESCRIPTION
# Summary

As someone who currently watches the repo, I find that there are a lot of notifications as the Storybook preview comment gets deleted and replaced on each push to WIP PRs. The deploy volume would be a little quieter if, instead of delete-then-comment, we updated the existing comment instead. So that's what this PR does.

## Problem statement

Noisy notifications when someone is actively pushing to a PR's branch.

For example:

<img width="3246" height="2950" alt="CleanShot 2026-06-30 at 13 06 01@2x" src="https://github.com/user-attachments/assets/1a0a2f86-4299-42b2-ad33-7e8abef98cf4" />


## Solution

There'll be one notification when the comment is first posted, but as the PR changes over time and the comment is updated, GitHub won't notify people who are subscribed to that PR.

## Testing and review


This might be a little less useful, if folks are depending on that comment to inform them when the deploy is available to look at. So feedback welcome on if this change is undesirable.

Here's the reference to the docs which give me confidence that this change is correct: https://octokit.github.io/rest.js/v22/#issues-update-comment