### PR TITLE
Add `pkg.pr.new` to enable publishing ephemeral packages

### DIFF
--- a/.github/workflows/publish-ephemeral-package.yml
+++ b/.github/workflows/publish-ephemeral-package.yml
@@ -13,8 +13,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish-ephemeral-package.yml
+++ b/.github/workflows/publish-ephemeral-package.yml
@@ -1,4 +1,4 @@
-name: Publish Any Commit
+name: Publish Ephemeral Package
 on: [push, pull_request]
 
 permissions: {}

--- a/.github/workflows/publish-ephemeral-package.yml
+++ b/.github/workflows/publish-ephemeral-package.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup project
         uses: ./.github/actions/setup

--- a/.github/workflows/publish-ephemeral-package.yml
+++ b/.github/workflows/publish-ephemeral-package.yml
@@ -11,16 +11,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - run: corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: "pnpm"
+          node-version: '20'
+          cache: 'npm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: npm ci
 
       - name: Build
-        run: pnpm build
+        run: npm run build
 
-      - run: pnpm exec pkg-pr-new publish --commentWithSha
+      - name: Publish
+        run: npx pkg-pr-new publish --commentWithSha

--- a/.github/workflows/publish-ephemeral-package.yml
+++ b/.github/workflows/publish-ephemeral-package.yml
@@ -1,5 +1,5 @@
 name: Publish Ephemeral Package
-on: [push, pull_request]
+on: [pull_request]
 
 permissions: {}
 

--- a/.github/workflows/publish-ephemeral-package.yml
+++ b/.github/workflows/publish-ephemeral-package.yml
@@ -1,0 +1,26 @@
+name: Publish Any Commit
+on: [push, pull_request]
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - run: pnpm exec pkg-pr-new publish --commentWithSha

--- a/.github/workflows/publish-ephemeral-package.yml
+++ b/.github/workflows/publish-ephemeral-package.yml
@@ -11,13 +11,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Setup project
+        uses: ./.github/actions/setup
 
       - name: Build
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "husky": "^9.1.7",
         "jsdom": "^29.1.1",
         "lightningcss": "^1.31.1",
+        "pkg-pr-new": "^0.0.75",
         "prettier": "^3.8.3",
         "run-pty": "^6.0.2",
         "serve-static": "^2.2.1",
@@ -13660,6 +13661,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkg-pr-new": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.75.tgz",
+      "integrity": "sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pkg-pr-new": "bin/cli.js"
       }
     },
     "node_modules/pkg-types": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",
     "lightningcss": "^1.31.1",
+    "pkg-pr-new": "^0.0.75",
     "prettier": "^3.8.3",
     "run-pty": "^6.0.2",
     "serve-static": "^2.2.1",


### PR DESCRIPTION
# Summary

Added and configured [`pkg.pr.new`](https://github.com/stackblitz-labs/pkg.pr.new) to publish ephemeral packages on every PR.

## Problem statement

Because the primary way end users will use this code is through installing the npm package, it would be helpful to be able to test and debug changes in real working applications. Currently, this requires either publishing a new package to npm or asking consumers to clone the repo and build and link locally. Neither of these is ideal.

## Solution

`pkg.pr.new` will create a new package on every PR, letting us test & debug components in real consuming applications with a lot less hassle.

Here it is working in a vanilla `npm create vite` app using the package published on this PR:
<img width="605" height="355" alt="image" src="https://github.com/user-attachments/assets/a5452161-5013-450e-a336-4b5516544a78" />
<img width="726" height="240" alt="image" src="https://github.com/user-attachments/assets/595cb4ef-dfc1-4864-825a-db6e3b45ef8f" />

## Testing and review

Is this a good idea? Anything that should be tweaked about the configuration?

## Dependency updates

| Dependency name              | Previous version | New version |
| :---------------------------- | :--------------: | :---------: |
| `pkg.pr.new`     |        --        |   `0.0.75` |

## Acknowledgments

Thank you, @IHIutch for suggesting this! It's so cool and does exactly what it says on the tin!
