### PR TITLE
Add meta test to ensure playwright versions match

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
     env:
       HOME: /root
     steps:

--- a/.github/workflows/update-playwright-snapshots.yml
+++ b/.github/workflows/update-playwright-snapshots.yml
@@ -14,7 +14,7 @@ jobs:
   screenshots:
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
     env:
       HOME: /root
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use official Playwright image with all browsers; version should match CI
-FROM mcr.microsoft.com/playwright:v1.60.0-noble
+FROM mcr.microsoft.com/playwright:v1.61.1-noble
 
 # Install system packages needed for development (if any)
 # RUN apt-get update && apt-get install -y <your-packages>

--- a/src/meta.test.js
+++ b/src/meta.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { execSync } from "child_process";
+
+describe("meta", () => {
+  function playwrightVersionFromPackageJson() {
+    const output = execSync(
+      "node_modules/.bin/playwright --version",
+    ).toString();
+    const version = output.match(/Version (\d+\.\d+.\d+)/)[1];
+    return version;
+  }
+
+  function findDockerPlaywrightReferences() {
+    const output = execSync(
+      "git ls-files | xargs grep --line-number mcr.microsoft.com/playwright",
+    )
+      .toString()
+      .trim();
+
+    return output.split("\n");
+  }
+
+  it("should reference the same version of Playwright everywhere", () => {
+    const expectedPlaywrightVersion = playwrightVersionFromPackageJson();
+    expect(expectedPlaywrightVersion).toBeTypeOf("string");
+
+    const otherReferences = findDockerPlaywrightReferences();
+
+    for (const reference of otherReferences) {
+      expect(
+        reference,
+        "When updating playwright, make sure to go manually update all of the Docker referencences to use the same version too",
+      ).toContain(expectedPlaywrightVersion);
+    }
+  });
+});

--- a/src/meta.test.js
+++ b/src/meta.test.js
@@ -12,7 +12,7 @@ describe("meta", () => {
 
   function findDockerPlaywrightReferences() {
     const output = execSync(
-      "git ls-files | xargs grep --line-number mcr.microsoft.com/playwright",
+      "git ls-files | xargs grep --line-number --extended-regexp mcr\.microsoft\.com/playwright",
     )
       .toString()
       .trim();


### PR DESCRIPTION
# Summary

Add a "meta" test which inspects the project config to make sure that we specify the same version of playwright everywhere we need to.


## Related issue

Closes #78

## Problem statement

When dependabot updates `@playwright/test` it updates playwright but it doesn't know how to also go update the Docker references, and then they drift out of sync.

## Solution

This commit basically greps for all of those and makes sure the specified version matches the version of playwright installed in `package.json`.

It also updates a few of these discrepancies that exist on main (just introduced today when we merged in https://github.com/open-government-design-system/ogds-elements/pull/98)

## Testing and review

- This implementation is kind of quick and dirty...
- Happy to break out a PR that just resolves the discrepancy if we want to merge that while we review and debate the meta test. it's kind of helpful that we have such a discrepancy on main to help demonstrate that the spec works though