### PR TITLE
Stop dependabot proposing vite major version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
       time: "08:00"
       timezone: "America/New_York"
       day: "monday"
+    ignore:
+      # vite 8 bundles with Rolldown instead of Rollup, which breaks
+      # vite-plugin-lit-css's sourcemap generation and fails the
+      # vite-plugin-bundlesize build check. Remove once that's fixed upstream.
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
     groups:
       components:
         patterns:


### PR DESCRIPTION
vite 8 switches from Rollup to Rolldown, which breaks vite-plugin-lit-css's sourcemap generation and fails the vite-plugin-bundlesize build check. Ignore vite major bumps until that's resolved upstream.

The whole sorrowful tale is in the misbegotten dependabot PR #40
