### PR TITLE
Remove list semantics and add `aria-description` to light DOM titles 

### DIFF
--- a/src/components/ogds-task-list/ogds-task-list-step.css
+++ b/src/components/ogds-task-list/ogds-task-list-step.css
@@ -119,6 +119,10 @@
   line-height: 1.5;
 }
 
+::slotted([slot="title"]) {
+  font: inherit;
+}
+
 /* Layout for the saved-data <dl>. dt/dd styles must come from global CSS —
    ::slotted() cannot reach descendants of slotted elements. */
 ::slotted(dl) {

--- a/src/components/ogds-task-list/ogds-task-list-step.ts
+++ b/src/components/ogds-task-list/ogds-task-list-step.ts
@@ -46,9 +46,6 @@ export class OgdsTaskListStep extends LitElement {
   override connectedCallback() {
     super.connectedCallback();
     adoptTokenStyles();
-    if (!this.hasAttribute("role")) {
-      this.setAttribute("role", "listitem");
-    }
   }
 
   private get _badgeLabel(): string {

--- a/src/components/ogds-task-list/ogds-task-list-step.ts
+++ b/src/components/ogds-task-list/ogds-task-list-step.ts
@@ -1,4 +1,5 @@
 import { css, html, LitElement, nothing, unsafeCSS } from "lit";
+import type { PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
 import iconCheckCircle from "../../shared/icons/check_circle.svg";
 import iconArrowForward from "../../shared/icons/arrow_forward.svg";
@@ -48,6 +49,34 @@ export class OgdsTaskListStep extends LitElement {
     adoptTokenStyles();
   }
 
+  override updated(changed: PropertyValues<this>) {
+    super.updated(changed);
+    this._syncTitleDescribedBy();
+  }
+
+  private _syncTitleDescribedBy = () => {
+    const titleSlot =
+      this.renderRoot?.querySelector<HTMLSlotElement>('slot[name="title"]');
+    if (!titleSlot) return;
+
+    const description = this._badgeText();
+
+    for (const el of titleSlot.assignedElements()) {
+      el.setAttribute("aria-description", description);
+    }
+  };
+
+  private _badgeText(): string {
+    const slot = this.renderRoot?.querySelector<HTMLSlotElement>(
+      'slot[name="status-label"]',
+    );
+    const text = (slot?.assignedNodes({ flatten: true }) ?? [])
+      .map((node) => node.textContent ?? "")
+      .join("")
+      .trim();
+    return text || this._badgeLabel;
+  }
+
   private get _badgeLabel(): string {
     const labels: Record<TaskStepStatus, string> = {
       completed: "Completed",
@@ -65,11 +94,17 @@ export class OgdsTaskListStep extends LitElement {
     return html`
       ${
         isBlocked
-          ? html`<span class="title" aria-describedby="blocked-message"
-              ><slot name="title"></slot
+          ? html`<span class="title" aria-describedby="badge"
+              ><slot
+                name="title"
+                @slotchange=${this._syncTitleDescribedBy}
+              ></slot
             ></span>`
           : html`<a class="title" href=${this.url} aria-describedby="badge">
-              <slot name="title"></slot
+              <slot
+                name="title"
+                @slotchange=${this._syncTitleDescribedBy}
+              ></slot
               ><span class="arrow" aria-hidden="true"></span>
             </a>`
       }
@@ -79,7 +114,9 @@ export class OgdsTaskListStep extends LitElement {
             ? html`<span class="badge-icon" aria-hidden="true"></span>`
             : nothing
         }
-        <slot name="status-label">${this._badgeLabel}</slot>
+        <slot name="status-label" @slotchange=${this._syncTitleDescribedBy}
+          >${this._badgeLabel}</slot
+        >
       </span>
       <slot name="alert"></slot>
       <slot name="description"></slot>

--- a/src/components/ogds-task-list/ogds-task-list.stories.ts
+++ b/src/components/ogds-task-list/ogds-task-list.stories.ts
@@ -20,23 +20,23 @@ export const Default = {
       <p slot="instruction">Finish all tasks to submit your application.</p>
 
       <ogds-task-list-step status="completed" url="/step-1">
-        <span slot="title">Tell us about you</span>
+        <h3 slot="title">Tell us about you</h3>
       </ogds-task-list-step>
 
       <ogds-task-list-step status="in-progress" url="/step-2">
-        <span slot="title">Set up your employer profile</span>
+        <h3 slot="title">Set up your employer profile</h3>
         <p slot="description">
           Confirm your legal entity structure, employer details, and EIN.
         </p>
       </ogds-task-list-step>
 
       <ogds-task-list-step status="not-started" url="/step-3">
-        <span slot="title">Enter the employer's address</span>
+        <h3 slot="title">Enter the employer's address</h3>
         <p slot="description">Tell us where the business is located.</p>
       </ogds-task-list-step>
 
       <ogds-task-list-step status="cannot-start-yet">
-        <span slot="title">Submit your Maryland Resident Agent details</span>
+        <h3 slot="title">Submit your Maryland Resident Agent details</h3>
       </ogds-task-list-step>
     </ogds-task-list>
   `,
@@ -48,7 +48,7 @@ export const AllStatuses = {
       <p slot="instruction">Each possible task state.</p>
 
       <ogds-task-list-step status="completed" url="/step-1">
-        <span slot="title">Completed task</span>
+        <h3 slot="title">Completed task</h3>
         <dl slot="saved-data">
           <dt>Phone number</dt>
           <dd>(410) 123-4567</dd>
@@ -56,21 +56,21 @@ export const AllStatuses = {
       </ogds-task-list-step>
 
       <ogds-task-list-step status="in-progress" url="/step-2">
-        <span slot="title">In progress task</span>
+        <h3 slot="title">In progress task</h3>
         <p slot="description">
           Short description explaining the value of completing this task.
         </p>
       </ogds-task-list-step>
 
       <ogds-task-list-step status="not-started" url="/step-3">
-        <span slot="title">Not started task</span>
+        <h3 slot="title">Not started task</h3>
         <p slot="description">
           Short description explaining the value of completing this task.
         </p>
       </ogds-task-list-step>
 
       <ogds-task-list-step status="cannot-start-yet">
-        <span slot="title">Cannot start yet task</span>
+        <h3 slot="title">Cannot start yet task</h3>
       </ogds-task-list-step>
     </ogds-task-list>
   `,
@@ -85,11 +85,11 @@ export const Translated = {
       </p>
 
       <ogds-task-list-step status="completed" url="/paso-1">
-        <span slot="title">Cuéntanos sobre ti</span>
+        <h3 slot="title">Cuéntanos sobre ti</h3>
       </ogds-task-list-step>
 
       <ogds-task-list-step status="not-started" url="/paso-2">
-        <span slot="title">Configura tu perfil de empleador</span>
+        <h3 slot="title">Configura tu perfil de empleador</h3>
       </ogds-task-list-step>
     </ogds-task-list>
   `,
@@ -109,7 +109,7 @@ export const StepOnly = {
   },
   render: () => html`
     <ogds-task-list-step status="in-progress" url="/some-task">
-      <span slot="title">Tell us about your employer</span>
+      <h3 slot="title">Tell us about your employer</h3>
       <p slot="description">
         We need a few details to verify your business registration.
       </p>

--- a/src/components/ogds-task-list/ogds-task-list.ts
+++ b/src/components/ogds-task-list/ogds-task-list.ts
@@ -70,9 +70,9 @@ export class OgdsTaskList extends LitElement {
           </${tag}>`}
           <slot name="instruction"></slot>
         </div>
-        <ul class="steps" role="list">
+        <div class="steps">
           <slot @slotchange=${this._onSlotChange}></slot>
-        </ul>
+        </div>
       </section>
     `;
   }


### PR DESCRIPTION
# Summary

Removed the list semantics on the `ogds-task-list` and `ogds-task-list-step` components in favor of using light DOM headings; also added `aria-description` attributes to those slotted headings—both changes to improve the screen reader experience.

## Problem statement

Some screen readers were having issues with the list semantics of this component as originally constructed, so in a [slack conversation](https://marylandfamli.slack.com/archives/C084EDPE0SG/p1783352703822339)🔒 we opted to try moving towards headings as the main landmark. Additionally, when testing in Safari+VoiceOver, the linked task titles behaved differently when accessed via the links panel of VO rotor vs the headings panel. 

## Solution

* To remove the list semantics, I replaced the task list's enclosing `ul` with a `div` and removed the `role="listitem"` from the task list steps.
* To give additional context for the headings, I added `aria-description` attributes to each heading. 

## Major changes

The titles of task steps that are available to begin contain both headings and links. Those that have links will have those links tied to the text of the status badge via `aria-describedby`.  This works because both the links and the badges are in the same shadow root. A user navigating by links will have the additional context of the badge text along with the linked task title. 

The headings are in the light DOM and so can't use `aria-describedby` where the pointer crosses into the shadow DOM. As such, the component now copies the badge text into an `aria-description` attribute on each heading. `aria-description` is a newer ARIA attribute, so support will not be as robust as `aria-describedby` so it is included here as a progressive enhancement feature. Another note on screen reader support: because there are both links and headings involved in these titles, screen reader behavior may be inconsistent. For instance, in Safari+VO, after navigating to an unlinked heading from the rotor, VO will read the heading, followed by "description: [badge text]." If the heading also includes a link, it won't include that description when navigating in that way. However, _it will_ include the description for linked headings as part of the links panel in the rotor. Having both of these options available, even if the support is somewhat inconsistent, will ideally give the most context possible for each navigation paradigm. 


