### PR TITLE
Implement Primary Nav component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -20,6 +20,7 @@ const config = {
     },
     "@storybook/addon-a11y",
     "storybook-addon-tag-badges",
+    "storybook/viewport",
   ],
   framework: {
     name: "@storybook/web-components-vite",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,4 +41,16 @@ export default [
     },
   },
   ...storybook.configs["flat/recommended"],
+  {
+    // "storybook/viewport" is bundled with the `storybook` package itself as
+    // of Storybook 9+ (no separate addon package to install), which
+    // `no-uninstalled-addons` doesn't yet account for.
+    files: [".storybook/main.@(js|cjs|mjs|ts)"],
+    rules: {
+      "storybook/no-uninstalled-addons": [
+        "error",
+        { ignore: ["storybook/viewport"] },
+      ],
+    },
+  },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,8 +43,8 @@ export default [
   ...storybook.configs["flat/recommended"],
   {
     // "storybook/viewport" is bundled with the `storybook` package itself as
-    // of Storybook 9+ (no separate addon package to install), which
-    // `no-uninstalled-addons` doesn't yet account for.
+    // of Storybook 9+, which
+    // `no-uninstalled-addons` doesn't yet account for. 🤷‍♂️
     files: [".storybook/main.@(js|cjs|mjs|ts)"],
     rules: {
       "storybook/no-uninstalled-addons": [

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,12 +1,14 @@
 import { OgdsBanner } from "./ogds-banner";
 import { OgdsAccordion } from "./ogds-accordion";
 import { OgdsAccordionToggle } from "./ogds-accordion-toggle";
+import { OgdsPrimaryNav } from "./ogds-primary-nav";
 import { OgdsTaskList, OgdsTaskListStep } from "./ogds-task-list";
 
 export {
   OgdsBanner,
   OgdsAccordion,
   OgdsAccordionToggle,
+  OgdsPrimaryNav,
   OgdsTaskList,
   OgdsTaskListStep,
 };

--- a/src/components/ogds-primary-nav/docs.mdx
+++ b/src/components/ogds-primary-nav/docs.mdx
@@ -1,0 +1,68 @@
+import { Meta, Title, Primary, Stories } from "@storybook/addon-docs/blocks";
+
+<Meta isTemplate />
+
+<Title />
+
+Based on the [USWDS Header component](https://designsystem.digital.gov/components/header/), which documents the primary nav as part of a full site header.
+
+The primary nav lists the main sections of a site. On narrow viewports its submenus behave like an accordion; on wide viewports they become dropdown menus.
+
+## Example Primary Nav
+
+<Primary />
+
+## Author markup
+
+`<ogds-primary-nav>` expects a single `<ul>` of `<li>` items:
+
+- A plain link item contains an `<a>`.
+- A submenu item contains a `<details>` with a `<summary>` (the visible toggle) followed by a nested `<ul>` of `<a>` links.
+
+```html
+<ogds-primary-nav>
+  <ul>
+    <li><a href="/" aria-current="page">Home</a></li>
+    <li>
+      <details>
+        <summary>Benefits</summary>
+        <ul>
+          <li><a href="/benefits/apply">Apply for benefits</a></li>
+          <li><a href="/benefits/status">Check application status</a></li>
+        </ul>
+      </details>
+    </li>
+    <li><a href="/about">About</a></li>
+  </ul>
+</ogds-primary-nav>
+```
+
+Add `aria-current="page"` to the current page's `<a>` to show the current-page indicator.
+
+## Guidance
+
+### This component only lays out the nav itself
+
+`<ogds-primary-nav>` handles the nav's own responsive layout — a stacked list that reflows into a horizontal bar with dropdown submenus at the desktop breakpoint (64rem) — and nothing else. It does not hide itself behind a menu button on narrow viewports. That's the responsibility of a parent component, such as a future `ogds-header`, which owns the trigger button, its `aria-expanded` state, and how the reveal looks (a slide-in panel, an overlay, etc.). Keeping that out of this component avoids guessing at a behavior a future `ogds-header` may need to implement differently.
+
+### Submenus require no JavaScript
+
+Submenus use the browser-native `<details>`/`<summary>` elements, so they open and close without JavaScript. `<ogds-primary-nav>` adds one enhancement when it upgrades: it gives every top-level `<details>` a shared `name`, so opening one submenu closes any other open submenu, matching the USWDS dropdown behavior. This is a progressive enhancement — you can opt into it yourself without JavaScript by giving each top-level `<details>` the same `name` attribute.
+
+## Custom Element vs CSS-Only Versions
+
+### Custom Element Behavior
+
+The examples on this page use the custom element `<ogds-primary-nav></ogds-primary-nav>`. This custom element uses all light DOM (no [shadow DOM](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM)), and it adds default `role="navigation"` and `aria-label="Primary navigation"` (unless you set your own), plus the submenu-exclusivity behavior described above.
+
+### Fallbacks without JavaScript
+
+1. **Native details/summary.** Submenus keep working without JavaScript because they use the native `<details>` element.
+2. **Styles.** As long as the component's styles are pulled into your application, the visual styling still works without JavaScript.
+3. **Class-based equivalent.** You can substitute `<div class="ogds-primary-nav">` in place of `<ogds-primary-nav>`. These are equivalent for styling, but since there's no JavaScript running you'll need to add `role="navigation"` and `aria-label` yourself, and give shared `name` attributes to top-level `<details>` elements for exclusive submenus.
+
+---
+
+## More Examples
+
+<Stories />

--- a/src/components/ogds-primary-nav/docs.mdx
+++ b/src/components/ogds-primary-nav/docs.mdx
@@ -43,23 +43,19 @@ Add `aria-current="page"` to the current page's `<a>` to show the current-page i
 
 ### This component only lays out the nav itself
 
-`<ogds-primary-nav>` handles the nav's own responsive layout — a stacked list that reflows into a horizontal bar with dropdown submenus at the desktop breakpoint (64rem) — and nothing else. It does not hide itself behind a menu button on narrow viewports. That's the responsibility of a parent component, such as a future `ogds-header`, which owns the trigger button, its `aria-expanded` state, and how the reveal looks (a slide-in panel, an overlay, etc.). Keeping that out of this component avoids guessing at a behavior a future `ogds-header` may need to implement differently.
+`<ogds-primary-nav>` handles the nav's own responsive layout. Like the USWDS nav it's based on, it collapses from a row into columns below desktop widths. It does not hide itself behind a menu button/hamburger on narrow viewports. That's the responsibility of its parent component.
 
-### Submenus require no JavaScript
+### Subnavs require no JavaScript
 
-Submenus use the browser-native `<details>`/`<summary>` elements, so they open and close without JavaScript. `<ogds-primary-nav>` adds one enhancement when it upgrades: it gives every top-level `<details>` a shared `name`, so opening one submenu closes any other open submenu, matching the USWDS dropdown behavior. This is a progressive enhancement — you can opt into it yourself without JavaScript by giving each top-level `<details>` the same `name` attribute.
+Subnavs use the browser-native `<details>`/`<summary>` elements, so they open and close without JavaScript. `<ogds-primary-nav>` adds one enhancement when it upgrades: it gives every top-level `<details>` a shared `name`, so opening one submenu closes any other open submenu, matching the USWDS dropdown behavior. The full web component version does also add `esc` button and "click outside to close" support.
 
 ## Custom Element vs CSS-Only Versions
 
-### Custom Element Behavior
-
-The examples on this page use the custom element `<ogds-primary-nav></ogds-primary-nav>`. This custom element uses all light DOM (no [shadow DOM](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM)), and it adds default `role="navigation"` and `aria-label="Primary navigation"` (unless you set your own), plus the submenu-exclusivity behavior described above.
-
 ### Fallbacks without JavaScript
 
-1. **Native details/summary.** Submenus keep working without JavaScript because they use the native `<details>` element.
+1. **Native details/summary.** Subnavs keep working without JavaScript because they use the native `<details>` element (besides exceptions noted above).
 2. **Styles.** As long as the component's styles are pulled into your application, the visual styling still works without JavaScript.
-3. **Class-based equivalent.** You can substitute `<div class="ogds-primary-nav">` in place of `<ogds-primary-nav>`. These are equivalent for styling, but since there's no JavaScript running you'll need to add `role="navigation"` and `aria-label` yourself, and give shared `name` attributes to top-level `<details>` elements for exclusive submenus.
+3. **Class-based equivalent.** You can substitute `<div class="ogds-primary-nav">` in place of `<ogds-primary-nav>`. These are equivalent for styling, but since there's no JavaScript running you'll need to add `role="navigation"` and `aria-label` yourself, and give shared `name` attributes to top-level `<details>` elements for exclusive subnavs.
 
 ---
 

--- a/src/components/ogds-primary-nav/docs.mdx
+++ b/src/components/ogds-primary-nav/docs.mdx
@@ -37,7 +37,8 @@ The primary nav lists the main sections of a site. On narrow viewports its subme
 </ogds-primary-nav>
 ```
 
-Add `aria-current="page"` to the current page's `<a>` to show the current-page indicator.
+Add `aria-current="page"` to the current page's `<a>` to show the current-page indicator. Because the logic for knowing where the user is in the application
+will depend heavily on the implementation, the app consuming the component is responsible for managing the `aria-current` attribute.
 
 ## Guidance
 

--- a/src/components/ogds-primary-nav/index.ts
+++ b/src/components/ogds-primary-nav/index.ts
@@ -13,18 +13,21 @@ let instanceCount = 0;
  * @summary A responsive primary navigation list, styled to match the USWDS primary nav.
  *
  * Author the nav as a single top-level `<ul>` of `<li>` items. A plain link item
- * should contain an `<a>`. A submenu item should contain a `<details>` with a
+ * should contain an `<a>`. A subnav item should contain a `<details>` with a
  * `<summary>` (the toggle) followed by a nested `<ul>` of `<a>` links — no
  * JavaScript is required for submenus to open and close.
  *
  * Add `aria-current="page"` to the `<a>` for the current page to show the
- * current-page indicator.
+ * current-page indicator. The logic to add that to the right item at the right time
+ * is up to the consuming application, but because the nav items are all light DOM
+ * that should be straightforward to do.
  *
  * This component only handles the nav's own layout: a stacked list that
  * reflows into a horizontal bar with dropdown submenus at the desktop
  * breakpoint. Hiding the nav behind a menu button on narrow viewports is a
  * parent component's job (e.g. a future `ogds-header`), since that also owns
  * the trigger button, its `aria-expanded` state, and how the reveal looks.
+ *
  *
  * @cssprop --ogds-primary-nav-current-indicator-color - Color of the bar under the current page's link.
  * @cssprop --ogds-primary-nav-focus-outline-color - Focus outline color.

--- a/src/components/ogds-primary-nav/index.ts
+++ b/src/components/ogds-primary-nav/index.ts
@@ -103,7 +103,8 @@ export class OgdsPrimaryNav extends LitElement {
   private _onDocumentClick = (event: MouseEvent) => {
     const target = event.target as Node | null;
     this._submenus.forEach((details) => {
-      if (details.open && target && !details.contains(target)) {
+      const shouldClose = details.open && target && !details.contains(target);
+      if (shouldClose) {
         details.open = false;
       }
     });

--- a/src/components/ogds-primary-nav/index.ts
+++ b/src/components/ogds-primary-nav/index.ts
@@ -1,0 +1,124 @@
+import { LitElement, nothing } from "lit";
+
+import styles from "./ogds-primary-nav.css";
+import iconChevronDown from "../../shared/icons/expand_more.svg";
+import iconChevronUp from "../../shared/icons/expand_less.svg";
+
+import { adoptTokenStyles } from "../../core/token-styles";
+import { defineCustomElement } from "../../utils";
+
+let instanceCount = 0;
+
+/**
+ * @summary A responsive primary navigation list, styled to match the USWDS primary nav.
+ *
+ * Author the nav as a single top-level `<ul>` of `<li>` items. A plain link item
+ * should contain an `<a>`. A submenu item should contain a `<details>` with a
+ * `<summary>` (the toggle) followed by a nested `<ul>` of `<a>` links — no
+ * JavaScript is required for submenus to open and close.
+ *
+ * Add `aria-current="page"` to the `<a>` for the current page to show the
+ * current-page indicator.
+ *
+ * This component only handles the nav's own layout: a stacked list that
+ * reflows into a horizontal bar with dropdown submenus at the desktop
+ * breakpoint. Hiding the nav behind a menu button on narrow viewports is a
+ * parent component's job (e.g. a future `ogds-header`), since that also owns
+ * the trigger button, its `aria-expanded` state, and how the reveal looks.
+ *
+ * @cssprop --ogds-primary-nav-current-indicator-color - Color of the bar under the current page's link.
+ * @cssprop --ogds-primary-nav-focus-outline-color - Focus outline color.
+ * @cssprop --ogds-primary-nav-font-family - Font family for nav text.
+ * @cssprop --ogds-primary-nav-font-size - Font size for nav text.
+ * @cssprop --ogds-primary-nav-link-color - Text color for links and submenu toggles.
+ * @cssprop --ogds-primary-nav-link-hover-background-color - Background color on hover below the desktop breakpoint.
+ * @cssprop --ogds-primary-nav-link-hover-color - Text color on hover at the desktop breakpoint.
+ * @cssprop --ogds-primary-nav-submenu-background-color - Background color of a submenu panel, and of its open toggle at the desktop breakpoint.
+ * @cssprop --ogds-primary-nav-submenu-link-color - Text color for links inside a submenu.
+ *
+ * @slot - Expects a single `<ul>` of `<li>` items, each containing either an `<a>` or a `<details>` submenu.
+ * @element ogds-primary-nav
+ */
+export class OgdsPrimaryNav extends LitElement {
+  /** @ignore */
+  private static _sheet: CSSStyleSheet | null = null;
+
+  private readonly _instanceName = `ogds-primary-nav-${++instanceCount}`;
+  private _submenus: HTMLDetailsElement[] = [];
+
+  override createRenderRoot() {
+    return this;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    adoptTokenStyles();
+    if (!OgdsPrimaryNav._sheet) {
+      OgdsPrimaryNav._sheet = new CSSStyleSheet();
+      OgdsPrimaryNav._sheet.replaceSync(
+        `ogds-primary-nav, .ogds-primary-nav {
+          --ogds-primary-nav-icon-chevron-down: url("${iconChevronDown}");
+          --ogds-primary-nav-icon-chevron-up: url("${iconChevronUp}");
+        }\n` + styles.cssText,
+      );
+      document.adoptedStyleSheets = [
+        ...document.adoptedStyleSheets,
+        OgdsPrimaryNav._sheet,
+      ];
+    }
+
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "navigation");
+    }
+    if (
+      !this.hasAttribute("aria-label") &&
+      !this.hasAttribute("aria-labelledby")
+    ) {
+      this.setAttribute("aria-label", "Primary navigation");
+    }
+
+    this._submenus = Array.from(
+      this.querySelectorAll<HTMLDetailsElement>(":scope > ul > li > details"),
+    );
+    this._submenus.forEach((details) => {
+      if (!details.hasAttribute("name")) {
+        details.setAttribute("name", this._instanceName);
+      }
+    });
+
+    document.addEventListener("click", this._onDocumentClick);
+    this.addEventListener("keydown", this._onKeydown);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    document.removeEventListener("click", this._onDocumentClick);
+    this.removeEventListener("keydown", this._onKeydown);
+  }
+
+  private _onDocumentClick = (event: MouseEvent) => {
+    const target = event.target as Node | null;
+    this._submenus.forEach((details) => {
+      if (details.open && target && !details.contains(target)) {
+        details.open = false;
+      }
+    });
+  };
+
+  private _onKeydown = (event: KeyboardEvent) => {
+    if (event.key !== "Escape") return;
+
+    const openSubmenu = this._submenus.find((details) => details.open);
+    if (openSubmenu) {
+      openSubmenu.open = false;
+      openSubmenu.querySelector<HTMLElement>(":scope > summary")?.focus();
+      event.stopPropagation();
+    }
+  };
+
+  render() {
+    return nothing;
+  }
+}
+
+defineCustomElement("ogds-primary-nav", OgdsPrimaryNav);

--- a/src/components/ogds-primary-nav/index.ts
+++ b/src/components/ogds-primary-nav/index.ts
@@ -33,6 +33,7 @@ let instanceCount = 0;
  * @cssprop --ogds-primary-nav-focus-outline-color - Focus outline color.
  * @cssprop --ogds-primary-nav-font-family - Font family for nav text.
  * @cssprop --ogds-primary-nav-font-size - Font size for nav text.
+ * @cssprop --ogds-primary-nav-icon-size - Height and width of the submenu toggle icon.
  * @cssprop --ogds-primary-nav-link-color - Text color for links and submenu toggles.
  * @cssprop --ogds-primary-nav-link-hover-background-color - Background color on hover below the desktop breakpoint.
  * @cssprop --ogds-primary-nav-link-hover-color - Text color on hover at the desktop breakpoint.

--- a/src/components/ogds-primary-nav/index.ts
+++ b/src/components/ogds-primary-nav/index.ts
@@ -1,6 +1,6 @@
 import { LitElement, nothing } from "lit";
 
-import styles from "./ogds-primary-nav.css";
+import cssFileStyles from "./ogds-primary-nav.css";
 import iconChevronDown from "../../shared/icons/expand_more.svg";
 import iconChevronUp from "../../shared/icons/expand_less.svg";
 
@@ -45,7 +45,7 @@ let instanceCount = 0;
  */
 export class OgdsPrimaryNav extends LitElement {
   /** @ignore */
-  private static _sheet: CSSStyleSheet | null = null;
+  private static _stylesheet: CSSStyleSheet | null = null;
 
   private readonly _instanceName = `ogds-primary-nav-${++instanceCount}`;
   private _submenus: HTMLDetailsElement[] = [];
@@ -57,17 +57,18 @@ export class OgdsPrimaryNav extends LitElement {
   override connectedCallback() {
     super.connectedCallback();
     adoptTokenStyles();
-    if (!OgdsPrimaryNav._sheet) {
-      OgdsPrimaryNav._sheet = new CSSStyleSheet();
-      OgdsPrimaryNav._sheet.replaceSync(
-        `ogds-primary-nav, .ogds-primary-nav {
-          --ogds-primary-nav-icon-chevron-down: url("${iconChevronDown}");
-          --ogds-primary-nav-icon-chevron-up: url("${iconChevronUp}");
-        }\n` + styles.cssText,
-      );
+    if (!OgdsPrimaryNav._stylesheet) {
+      const localStyles = `ogds-primary-nav, .ogds-primary-nav {
+        --ogds-primary-nav-icon-chevron-down: url("${iconChevronDown}");
+        --ogds-primary-nav-icon-chevron-up: url("${iconChevronUp}");
+      }`;
+      const combinedStylesheetsToAdopt = `${localStyles}\n${cssFileStyles.cssText}`;
+
+      OgdsPrimaryNav._stylesheet = new CSSStyleSheet();
+      OgdsPrimaryNav._stylesheet.replaceSync(combinedStylesheetsToAdopt);
       document.adoptedStyleSheets = [
         ...document.adoptedStyleSheets,
-        OgdsPrimaryNav._sheet,
+        OgdsPrimaryNav._stylesheet,
       ];
     }
 

--- a/src/components/ogds-primary-nav/ogds-primary-nav.css
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.css
@@ -1,0 +1,164 @@
+@layer ogds.components;
+
+@layer ogds.components {
+  .ogds-primary-nav,
+  ogds-primary-nav {
+    --ogds-primary-nav-current-indicator-color: var(
+      --ogds-theme-color-primary,
+      #005ea2
+    );
+    --ogds-primary-nav-focus-outline-color: var(
+      --ogds-theme-focus-color,
+      #2491ff
+    );
+    --ogds-primary-nav-font-family: system-ui, sans-serif;
+    --ogds-primary-nav-font-size: var(--ogds-theme-type-scale-md, 1.0625rem);
+    --ogds-primary-nav-link-color: var(--ogds-theme-text-color, #1b1b1b);
+    --ogds-primary-nav-link-hover-background-color: var(
+      --ogds-theme-color-base-lightest,
+      #f0f0f0
+    );
+    --ogds-primary-nav-link-hover-color: var(
+      --ogds-theme-color-primary,
+      #005ea2
+    );
+    --ogds-primary-nav-submenu-background-color: var(
+      --ogds-theme-color-primary-darker,
+      #162e51
+    );
+    --ogds-primary-nav-submenu-link-color: var(
+      --ogds-theme-text-reverse-color,
+      #fff
+    );
+
+    box-sizing: border-box;
+    display: block;
+    font-family: var(--ogds-primary-nav-font-family);
+    font-size: var(--ogds-primary-nav-font-size);
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    > ul {
+      display: flex;
+      flex-direction: column;
+    }
+
+    li {
+      position: relative;
+    }
+
+    a,
+    summary {
+      align-items: center;
+      color: var(--ogds-primary-nav-link-color);
+      cursor: pointer;
+      display: flex;
+      font-weight: 700;
+      gap: 0.5rem;
+      justify-content: space-between;
+      padding: var(--ogds-spacing-105, 0.75rem) var(--ogds-spacing-2, 1rem);
+      text-decoration: none;
+
+      &:hover {
+        background-color: var(--ogds-primary-nav-link-hover-background-color);
+      }
+
+      &:focus-visible {
+        outline: 0.25rem solid var(--ogds-primary-nav-focus-outline-color);
+      }
+    }
+
+    a[aria-current="page"] {
+      box-shadow: inset 0 -0.25rem 0
+        var(--ogds-primary-nav-current-indicator-color);
+    }
+
+    summary {
+      list-style: none;
+
+      &::-webkit-details-marker {
+        display: none;
+      }
+
+      &::after {
+        background-color: currentColor;
+        content: "";
+        flex-shrink: 0;
+        height: 1.25rem;
+        mask-image: var(--ogds-primary-nav-icon-chevron-down);
+        mask-position: center;
+        mask-repeat: no-repeat;
+        mask-size: contain;
+        width: 1.25rem;
+      }
+    }
+
+    details[open] > summary::after {
+      mask-image: var(--ogds-primary-nav-icon-chevron-up);
+    }
+
+    details > ul {
+      background-color: var(--ogds-primary-nav-submenu-background-color);
+      padding-block: var(--ogds-spacing-1, 0.5rem);
+    }
+
+    details > ul a {
+      color: var(--ogds-primary-nav-submenu-link-color);
+      font-weight: 400;
+      padding-inline-start: var(--ogds-spacing-4, 2rem);
+
+      &:hover {
+        background-color: transparent;
+        text-decoration: underline;
+      }
+
+      &:focus-visible {
+        outline-offset: -0.25rem;
+      }
+    }
+
+    /**
+     * The breakpoint below is not exposed as a custom property because CSS
+     * media queries cannot read custom property values. Keep it in sync with
+     * --ogds-breakpoint-desktop from @ogds/tokens.
+     */
+    @media (width >= 64rem) {
+      > ul {
+        align-items: stretch;
+        flex-direction: row;
+      }
+
+      > ul > li {
+        display: flex;
+      }
+
+      a:hover,
+      details:not([open]) > summary:hover {
+        background-color: transparent;
+        color: var(--ogds-primary-nav-link-hover-color);
+      }
+
+      details[open] > summary {
+        background-color: var(--ogds-primary-nav-submenu-background-color);
+        color: var(--ogds-primary-nav-submenu-link-color);
+      }
+
+      details > ul {
+        inline-size: 15rem;
+        inset-inline-start: 0;
+        position: absolute;
+        top: 100%;
+      }
+    }
+  }
+}

--- a/src/components/ogds-primary-nav/ogds-primary-nav.css
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.css
@@ -54,7 +54,12 @@
     }
 
     li {
+      padding: var(--ogds-spacing-105, 0.75rem) var(--ogds-spacing-2, 1rem);
       position: relative;
+    }
+
+    > ul > li:first-child a {
+      padding-inline-start: 0;
     }
 
     a,
@@ -66,21 +71,26 @@
       font-weight: 700;
       gap: 0.5rem;
       justify-content: space-between;
-      padding: var(--ogds-spacing-105, 0.75rem) var(--ogds-spacing-2, 1rem);
       text-decoration: none;
-
-      &:hover {
-        background-color: var(--ogds-primary-nav-link-hover-background-color);
-      }
 
       &:focus-visible {
         outline: 0.25rem solid var(--ogds-primary-nav-focus-outline-color);
       }
     }
 
-    a[aria-current="page"] {
-      box-shadow: inset 0 -0.25rem 0
-        var(--ogds-primary-nav-current-indicator-color);
+    > ul > li > a:hover,
+    > ul > li > a[aria-current="page"],
+    > ul > li > details:not([open]) > summary:hover {
+      position: relative;
+
+      &::before {
+        background-color: var(--ogds-primary-nav-current-indicator-color);
+        bottom: -0.5rem;
+        content: "";
+        height: 0.25rem;
+        inset-inline: 0;
+        position: absolute;
+      }
     }
 
     summary {
@@ -146,10 +156,13 @@
           background-color: transparent;
           color: var(--ogds-primary-nav-link-hover-color);
         }
+
+        &:has(> details[open]) {
+          background-color: var(--ogds-primary-nav-submenu-background-color);
+        }
       }
 
       details[open] > summary {
-        background-color: var(--ogds-primary-nav-submenu-background-color);
         color: var(--ogds-primary-nav-submenu-link-color);
       }
 

--- a/src/components/ogds-primary-nav/ogds-primary-nav.css
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.css
@@ -148,6 +148,10 @@
         flex-direction: row;
       }
 
+      li {
+        padding-block: var(--ogds-spacing-1, 0.5rem);
+      }
+
       > ul > li {
         display: flex;
 
@@ -171,6 +175,10 @@
         inset-inline-start: 0;
         position: absolute;
         top: 100%;
+
+        a {
+          padding-inline-start: 0;
+        }
       }
     }
   }

--- a/src/components/ogds-primary-nav/ogds-primary-nav.css
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.css
@@ -140,12 +140,12 @@
 
       > ul > li {
         display: flex;
-      }
 
-      a:hover,
-      details:not([open]) > summary:hover {
-        background-color: transparent;
-        color: var(--ogds-primary-nav-link-hover-color);
+        > a:hover,
+        > details:not([open]) > summary:hover {
+          background-color: transparent;
+          color: var(--ogds-primary-nav-link-hover-color);
+        }
       }
 
       details[open] > summary {

--- a/src/components/ogds-primary-nav/ogds-primary-nav.css
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.css
@@ -13,6 +13,7 @@
     );
     --ogds-primary-nav-font-family: system-ui, sans-serif;
     --ogds-primary-nav-font-size: var(--ogds-theme-type-scale-md, 1.0625rem);
+    --ogds-primary-nav-icon-size: 1.25rem;
     --ogds-primary-nav-link-color: var(--ogds-theme-text-color, #1b1b1b);
     --ogds-primary-nav-link-hover-background-color: var(
       --ogds-theme-color-base-lightest,
@@ -104,12 +105,12 @@
         background-color: currentColor;
         content: "";
         flex-shrink: 0;
-        height: 1.25rem;
+        height: var(--ogds-primary-nav-icon-size);
         mask-image: var(--ogds-primary-nav-icon-chevron-down);
         mask-position: center;
         mask-repeat: no-repeat;
         mask-size: contain;
-        width: 1.25rem;
+        width: var(--ogds-primary-nav-icon-size);
       }
     }
 

--- a/src/components/ogds-primary-nav/ogds-primary-nav.spec.ts
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.spec.ts
@@ -7,7 +7,7 @@ vi.mock("../../core/token-styles", () => ({ adoptTokenStyles: vi.fn() }));
 
 import { OgdsPrimaryNav } from "./index";
 
-const twoSections = `
+const examplePrimaryNavigation = `
   <ul>
     <li><a href="/" aria-current="page">Home</a></li>
     <li>
@@ -49,28 +49,32 @@ afterEach(() => {
 
 describe("default ARIA", () => {
   it("sets role=navigation when no role is present", async () => {
-    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    const el = mount(
+      `<ogds-primary-nav>${examplePrimaryNavigation}</ogds-primary-nav>`,
+    );
     await el.updateComplete;
     expect(el.getAttribute("role")).toBe("navigation");
   });
 
   it("does not override an author-supplied role", async () => {
     const el = mount(
-      `<ogds-primary-nav role="menu">${twoSections}</ogds-primary-nav>`,
+      `<ogds-primary-nav role="menu">${examplePrimaryNavigation}</ogds-primary-nav>`,
     );
     await el.updateComplete;
     expect(el.getAttribute("role")).toBe("menu");
   });
 
   it("defaults aria-label to 'Primary navigation'", async () => {
-    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    const el = mount(
+      `<ogds-primary-nav>${examplePrimaryNavigation}</ogds-primary-nav>`,
+    );
     await el.updateComplete;
     expect(el.getAttribute("aria-label")).toBe("Primary navigation");
   });
 
   it("does not override an author-supplied aria-label", async () => {
     const el = mount(
-      `<ogds-primary-nav aria-label="Site">${twoSections}</ogds-primary-nav>`,
+      `<ogds-primary-nav aria-label="Site">${examplePrimaryNavigation}</ogds-primary-nav>`,
     );
     await el.updateComplete;
     expect(el.getAttribute("aria-label")).toBe("Site");
@@ -78,7 +82,7 @@ describe("default ARIA", () => {
 
   it("does not set aria-label when aria-labelledby is present", async () => {
     const el = mount(
-      `<ogds-primary-nav aria-labelledby="nav-heading">${twoSections}</ogds-primary-nav>`,
+      `<ogds-primary-nav aria-labelledby="nav-heading">${examplePrimaryNavigation}</ogds-primary-nav>`,
     );
     await el.updateComplete;
     expect(el.hasAttribute("aria-label")).toBe(false);
@@ -87,7 +91,9 @@ describe("default ARIA", () => {
 
 describe("submenu exclusivity", () => {
   it("assigns a shared name to top-level submenus so only one stays open", async () => {
-    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    const el = mount(
+      `<ogds-primary-nav>${examplePrimaryNavigation}</ogds-primary-nav>`,
+    );
     await el.updateComplete;
     const [first, second] = Array.from(el.querySelectorAll("details"));
     expect(first.name).not.toBe("");
@@ -114,7 +120,9 @@ describe("submenu exclusivity", () => {
 
 describe("outside click", () => {
   it("closes an open submenu when clicking outside it", async () => {
-    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    const el = mount(
+      `<ogds-primary-nav>${examplePrimaryNavigation}</ogds-primary-nav>`,
+    );
     await el.updateComplete;
     const details = el.querySelector("details") as HTMLDetailsElement;
     details.open = true;
@@ -125,7 +133,9 @@ describe("outside click", () => {
   });
 
   it("does not close a submenu when clicking a link inside it", async () => {
-    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    const el = mount(
+      `<ogds-primary-nav>${examplePrimaryNavigation}</ogds-primary-nav>`,
+    );
     await el.updateComplete;
     const details = el.querySelector("details") as HTMLDetailsElement;
     details.open = true;
@@ -138,7 +148,9 @@ describe("outside click", () => {
 
 describe("keyboard", () => {
   it("on Escape key press, the open submenu is closed and focus moves to its summary ", async () => {
-    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    const el = mount(
+      `<ogds-primary-nav>${examplePrimaryNavigation}</ogds-primary-nav>`,
+    );
     await el.updateComplete;
     const details = el.querySelector("details") as HTMLDetailsElement;
     details.open = true;
@@ -154,14 +166,20 @@ describe("keyboard", () => {
 
 describe("stylesheet adoption", () => {
   it("adds a stylesheet to document.adoptedStyleSheets on first mount", async () => {
-    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    const el = mount(
+      `<ogds-primary-nav>${examplePrimaryNavigation}</ogds-primary-nav>`,
+    );
     await el.updateComplete;
     expect(document.adoptedStyleSheets).toHaveLength(1);
   });
 
   it("does not add the stylesheet more than once when multiple navs are mounted", async () => {
-    const el1 = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
-    const el2 = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    const el1 = mount(
+      `<ogds-primary-nav>${examplePrimaryNavigation}</ogds-primary-nav>`,
+    );
+    const el2 = mount(
+      `<ogds-primary-nav>${examplePrimaryNavigation}</ogds-primary-nav>`,
+    );
     await Promise.all([el1.updateComplete, el2.updateComplete]);
     expect(document.adoptedStyleSheets).toHaveLength(1);
   });

--- a/src/components/ogds-primary-nav/ogds-primary-nav.spec.ts
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.spec.ts
@@ -40,7 +40,7 @@ function mount(html: string): OgdsPrimaryNav {
 
 beforeEach(() => {
   document.adoptedStyleSheets = [];
-  (OgdsPrimaryNav as any)._sheet = null;
+  (OgdsPrimaryNav as any)._stylesheet = null;
 });
 
 afterEach(() => {

--- a/src/components/ogds-primary-nav/ogds-primary-nav.spec.ts
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.spec.ts
@@ -137,7 +137,7 @@ describe("outside click", () => {
 });
 
 describe("keyboard", () => {
-  it("closes an open submenu and refocuses its summary on Escape", async () => {
+  it("on Escape key press, the open submenu is closed and focus moves to its summary ", async () => {
     const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
     await el.updateComplete;
     const details = el.querySelector("details") as HTMLDetailsElement;

--- a/src/components/ogds-primary-nav/ogds-primary-nav.spec.ts
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.spec.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("./ogds-primary-nav.css", () => ({ default: { cssText: "" } }));
+vi.mock("../../shared/icons/expand_more.svg", () => ({ default: "" }));
+vi.mock("../../shared/icons/expand_less.svg", () => ({ default: "" }));
+vi.mock("../../core/token-styles", () => ({ adoptTokenStyles: vi.fn() }));
+
+import { OgdsPrimaryNav } from "./index";
+
+const twoSections = `
+  <ul>
+    <li><a href="/" aria-current="page">Home</a></li>
+    <li>
+      <details>
+        <summary>Section one</summary>
+        <ul>
+          <li><a href="/one/a">One A</a></li>
+          <li><a href="/one/b">One B</a></li>
+        </ul>
+      </details>
+    </li>
+    <li>
+      <details>
+        <summary>Section two</summary>
+        <ul>
+          <li><a href="/two/a">Two A</a></li>
+        </ul>
+      </details>
+    </li>
+  </ul>
+`;
+
+function mount(html: string): OgdsPrimaryNav {
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  const el = container.firstElementChild as OgdsPrimaryNav;
+  document.body.appendChild(el);
+  return el;
+}
+
+beforeEach(() => {
+  document.adoptedStyleSheets = [];
+  (OgdsPrimaryNav as any)._sheet = null;
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("default ARIA", () => {
+  it("sets role=navigation when no role is present", async () => {
+    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    await el.updateComplete;
+    expect(el.getAttribute("role")).toBe("navigation");
+  });
+
+  it("does not override an author-supplied role", async () => {
+    const el = mount(
+      `<ogds-primary-nav role="menu">${twoSections}</ogds-primary-nav>`,
+    );
+    await el.updateComplete;
+    expect(el.getAttribute("role")).toBe("menu");
+  });
+
+  it("defaults aria-label to 'Primary navigation'", async () => {
+    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    await el.updateComplete;
+    expect(el.getAttribute("aria-label")).toBe("Primary navigation");
+  });
+
+  it("does not override an author-supplied aria-label", async () => {
+    const el = mount(
+      `<ogds-primary-nav aria-label="Site">${twoSections}</ogds-primary-nav>`,
+    );
+    await el.updateComplete;
+    expect(el.getAttribute("aria-label")).toBe("Site");
+  });
+
+  it("does not set aria-label when aria-labelledby is present", async () => {
+    const el = mount(
+      `<ogds-primary-nav aria-labelledby="nav-heading">${twoSections}</ogds-primary-nav>`,
+    );
+    await el.updateComplete;
+    expect(el.hasAttribute("aria-label")).toBe(false);
+  });
+});
+
+describe("submenu exclusivity", () => {
+  it("assigns a shared name to top-level submenus so only one stays open", async () => {
+    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    await el.updateComplete;
+    const [first, second] = Array.from(el.querySelectorAll("details"));
+    expect(first.name).not.toBe("");
+    expect(first.name).toBe(second.name);
+  });
+
+  it("does not overwrite an author-supplied name", async () => {
+    const el = mount(`
+      <ogds-primary-nav>
+        <ul>
+          <li>
+            <details name="custom">
+              <summary>Section</summary>
+              <ul><li><a href="/a">A</a></li></ul>
+            </details>
+          </li>
+        </ul>
+      </ogds-primary-nav>
+    `);
+    await el.updateComplete;
+    expect(el.querySelector("details")?.getAttribute("name")).toBe("custom");
+  });
+});
+
+describe("outside click", () => {
+  it("closes an open submenu when clicking outside it", async () => {
+    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    await el.updateComplete;
+    const details = el.querySelector("details") as HTMLDetailsElement;
+    details.open = true;
+
+    document.body.click();
+
+    expect(details.open).toBe(false);
+  });
+
+  it("does not close a submenu when clicking a link inside it", async () => {
+    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    await el.updateComplete;
+    const details = el.querySelector("details") as HTMLDetailsElement;
+    details.open = true;
+
+    details.querySelector("a")?.click();
+
+    expect(details.open).toBe(true);
+  });
+});
+
+describe("keyboard", () => {
+  it("closes an open submenu and refocuses its summary on Escape", async () => {
+    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    await el.updateComplete;
+    const details = el.querySelector("details") as HTMLDetailsElement;
+    details.open = true;
+
+    el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+
+    expect(details.open).toBe(false);
+    expect(document.activeElement).toBe(details.querySelector("summary"));
+  });
+});
+
+describe("stylesheet adoption", () => {
+  it("adds a stylesheet to document.adoptedStyleSheets on first mount", async () => {
+    const el = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    await el.updateComplete;
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+  });
+
+  it("does not add the stylesheet more than once when multiple navs are mounted", async () => {
+    const el1 = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    const el2 = mount(`<ogds-primary-nav>${twoSections}</ogds-primary-nav>`);
+    await Promise.all([el1.updateComplete, el2.updateComplete]);
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+  });
+});

--- a/src/components/ogds-primary-nav/ogds-primary-nav.stories.ts
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.stories.ts
@@ -1,0 +1,71 @@
+import { html } from "lit";
+import "./index";
+import ComponentDocs from "./docs.mdx";
+
+const items = html`
+  <ul>
+    <li><a href="#" aria-current="page">Current section</a></li>
+    <li>
+      <details>
+        <summary>Benefits</summary>
+        <ul>
+          <li><a href="#">Apply for benefits</a></li>
+          <li><a href="#">Check application status</a></li>
+          <li><a href="#">Manage your account</a></li>
+        </ul>
+      </details>
+    </li>
+    <li>
+      <details>
+        <summary>Resources</summary>
+        <ul>
+          <li><a href="#">Guides</a></li>
+          <li><a href="#">FAQ</a></li>
+        </ul>
+      </details>
+    </li>
+    <li><a href="#">About</a></li>
+    <li><a href="#">Contact</a></li>
+  </ul>
+`;
+
+export default {
+  title: "Components/Primary Nav",
+  component: "ogds-primary-nav",
+  tags: ["experimental"],
+  parameters: {
+    docs: {
+      page: ComponentDocs,
+    },
+  },
+};
+
+export const Default = {
+  render: () => html`<ogds-primary-nav>${items}</ogds-primary-nav>`,
+};
+
+export const WithoutCustomElement = {
+  render: () =>
+    html`<div
+      class="ogds-primary-nav"
+      role="navigation"
+      aria-label="Primary navigation"
+    >
+      ${items}
+    </div>`,
+};
+
+export const Mobile = {
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The nav reflows into a stacked list below the desktop breakpoint (64rem).",
+      },
+    },
+  },
+  render: () => html`<ogds-primary-nav>${items}</ogds-primary-nav>`,
+};


### PR DESCRIPTION
# Summary

Added a primary nav component to match the existing [USWDS header component](url)'s primary nav look, feel, and behavior, but with similar architecture to `ogds-accordion`.

## Preview link

Storybook and preview package below.

## Problem statement

The header component ([Figma 🔒](https://www.figma.com/design/iq2uIT1HNmjukdSrYXSrjV/-Approved--FAMLI-Header?node-id=900-17388&m=dev)) needs a primary nav. Or rather, it will almost always have one, so it might be helpful to have an easier off-the-shelf component for this.

## Solution

The layout is similar to the USWDS flexbox implementation (with an absolutely positioned open state). Also similarly to the USWDS nav, it uses an accordion-like architecture for interactivity. However, whereas the USWDS primary nav uses its button-based accordion, this one uses `details`/`summary` like the `ogds-accordion` (though it doesn't use the literal accordion component—as cool as that would be, it would probably take major surgery to make that possible).

This component owns its own responsive behavior, collapsing from rows to columns at sub-desktop widths. That said, it doesn't do its own hamburger menu/drawer behavior, since that will be handled by the header component.

## Testing and review

You can test this in the below storybook, or if you're extra eager you can install the test package and mess around with it. There are likely going to be some changes to this to make it play nicely with the header component, so I'd argue some rough edges are ok at this stage. I just wanted to get this component in so it can compose into the header rather than trying to do it all in one giant PR.