### PR TITLE
Implement OGDS header

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,7 @@
 import { OgdsBanner } from "./ogds-banner";
 import { OgdsAccordion } from "./ogds-accordion";
 import { OgdsAccordionToggle } from "./ogds-accordion-toggle";
+import { OgdsHeader } from "./ogds-header";
 import { OgdsPrimaryNav } from "./ogds-primary-nav";
 import { OgdsTaskList, OgdsTaskListStep } from "./ogds-task-list";
 
@@ -8,6 +9,7 @@ export {
   OgdsBanner,
   OgdsAccordion,
   OgdsAccordionToggle,
+  OgdsHeader,
   OgdsPrimaryNav,
   OgdsTaskList,
   OgdsTaskListStep,

--- a/src/components/ogds-header/docs.mdx
+++ b/src/components/ogds-header/docs.mdx
@@ -1,0 +1,60 @@
+import { Meta, Title, Primary, Stories } from "@storybook/addon-docs/blocks";
+
+<Meta isTemplate />
+
+<Title />
+
+Based on the [USWDS Header component](https://designsystem.digital.gov/components/header/), supporting both the basic and extended variants (but not megamenu at the moment).
+
+## Example
+
+<Primary />
+
+## Author markup
+
+`<ogds-header>` is a slot-based shell. The consuming app provides the content, the component provides layout and the responsive layout/drawer behavior.
+
+```html
+<ogds-header variant="extended">
+  <div slot="logo"><a href="/">Project name</a></div>
+  <div slot="notifications">Notifications</div>
+  <div slot="info">Alert or banner content</div>
+
+  <ul slot="nav-secondary">
+    <li><a href="#">One</a></li>
+  </ul>
+  <form slot="nav-secondary"><input type="search" /></form>
+
+  <ogds-primary-nav slot="nav-primary">
+    <ul>
+      <li><a href="#" aria-current="page">Current section</a></li>
+    </ul>
+  </ogds-primary-nav>
+</ogds-header>
+```
+
+| Slot            | Required | Notes                                                                                                                                                                 |
+| --------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `logo`          | Yes      | Typically a link to the homepage.                                                                                                                                     |
+| `nav-primary`   | Yes      | Expects an `<ogds-primary-nav>`.                                                                                                                                      |
+| `nav-secondary` | No       | Links and/or a search form. Aligned with the logo at desktop widths in the extended variant; folds into the drawer with the primary nav below the desktop breakpoint. The component consumer is responsible for the contents here and ensuring they implement responsive behavior |
+| `notifications` | No       | Shown in the same row as the primary nav. It's called "notifications" but doesn't need to be that.                                                                    |
+| `info`          | No       | A banner/alert row between the navbar and the nav drawer.                                                                                                             |
+
+Optional slots that receive no content aren't rendered. Omit them rather than passing an empty element.
+
+## `variant` attribute
+
+- `extended` (default) — secondary nav appears in its own area, aligned with the logo, at desktop widths.
+- `basic` — secondary nav sits inline alongside the primary nav instead.
+
+## Responsive behavior
+
+Below the desktop breakpoint (64rem), the primary and secondary nav collapse into a `<dialog>` drawer that slides in from the right when the menu button is pressed.
+This includes a backdrop, a focus trap, and Escape-to-close, all native to `<dialog>`.
+
+---
+
+## More Examples
+
+<Stories />

--- a/src/components/ogds-header/docs.mdx
+++ b/src/components/ogds-header/docs.mdx
@@ -12,7 +12,12 @@ Based on the [USWDS Header component](https://designsystem.digital.gov/component
 
 ## Author markup
 
-`<ogds-header>` is a slot-based shell. The consuming app provides the content, the component provides layout and the responsive layout/drawer behavior.
+`<ogds-header>` is a slot-based shell. The consuming app provides the content, and the component provides layout and the responsive layout/drawer behavior.
+The slot architecture is meant to reflect the known existing use cases from USWDS and specific variants for state agency (Maryland) use cases. Because the
+secondary nav area (on the right side of the header at desktop widths) will vary drastically both in terms of design and implementation (for functionality
+like search, account info, etc.), it is mostly an empty logic-less slot that can accommodate arbitrary content, but does not have opinions about that content.
+All of the examples here use the `ogds-primary-nav` component in the primary nav slot, but if that component does not work for your use case (i.e. you need
+megamenu support or there is existing logic in your nav implementation that would be tricky to port to the component) then it should work with your exisiting nav.
 
 ```html
 <ogds-header variant="extended">
@@ -33,13 +38,11 @@ Based on the [USWDS Header component](https://designsystem.digital.gov/component
 </ogds-header>
 ```
 
-| Slot            | Required | Notes                                                                                                                                                                                                                                                                             |
-| --------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `logo`          | Yes      | Typically a link to the homepage.                                                                                                                                                                                                                                                 |
-| `nav-primary`   | Yes      | Expects an `<ogds-primary-nav>`.                                                                                                                                                                                                                                                  |
-| `nav-secondary` | No       | Links and/or a search form. Aligned with the logo at desktop widths in the extended variant; folds into the drawer with the primary nav below the desktop breakpoint. The component consumer is responsible for the contents here and ensuring they implement responsive behavior |
-| `notifications` | No       | Shown in the same row as the primary nav. It's called "notifications" but doesn't need to be that.                                                                                                                                                                                |
-| `info`          | No       | A banner/alert row between the navbar and the nav drawer.                                                                                                                                                                                                                         |
+- **`logo`** (required) — Typically a link to the homepage.
+- **`nav-primary`** (required) — Expects an `<ogds-primary-nav>`.
+- **`nav-secondary`** (optional) — Links and/or a search form. Aligned with the logo at desktop widths in the extended variant; folds into the drawer with the primary nav below the desktop breakpoint. The component consumer is responsible for the contents here and for implementing responsive behavior.
+- **`notifications`** (optional) — Shown in the same row as the primary nav. It's called "notifications" but doesn't need to be that.
+- **`info`** (optional) — A banner/alert row between the navbar and the nav drawer.
 
 Optional slots that receive no content aren't rendered. Omit them rather than passing an empty element.
 

--- a/src/components/ogds-header/docs.mdx
+++ b/src/components/ogds-header/docs.mdx
@@ -33,13 +33,13 @@ Based on the [USWDS Header component](https://designsystem.digital.gov/component
 </ogds-header>
 ```
 
-| Slot            | Required | Notes                                                                                                                                                                 |
-| --------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `logo`          | Yes      | Typically a link to the homepage.                                                                                                                                     |
-| `nav-primary`   | Yes      | Expects an `<ogds-primary-nav>`.                                                                                                                                      |
+| Slot            | Required | Notes                                                                                                                                                                                                                                                                             |
+| --------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `logo`          | Yes      | Typically a link to the homepage.                                                                                                                                                                                                                                                 |
+| `nav-primary`   | Yes      | Expects an `<ogds-primary-nav>`.                                                                                                                                                                                                                                                  |
 | `nav-secondary` | No       | Links and/or a search form. Aligned with the logo at desktop widths in the extended variant; folds into the drawer with the primary nav below the desktop breakpoint. The component consumer is responsible for the contents here and ensuring they implement responsive behavior |
-| `notifications` | No       | Shown in the same row as the primary nav. It's called "notifications" but doesn't need to be that.                                                                    |
-| `info`          | No       | A banner/alert row between the navbar and the nav drawer.                                                                                                             |
+| `notifications` | No       | Shown in the same row as the primary nav. It's called "notifications" but doesn't need to be that.                                                                                                                                                                                |
+| `info`          | No       | A banner/alert row between the navbar and the nav drawer.                                                                                                                                                                                                                         |
 
 Optional slots that receive no content aren't rendered. Omit them rather than passing an empty element.
 

--- a/src/components/ogds-header/docs.mdx
+++ b/src/components/ogds-header/docs.mdx
@@ -40,7 +40,7 @@ megamenu support or there is existing logic in your nav implementation that woul
 
 - **`logo`** (required) — Typically a link to the homepage.
 - **`nav-primary`** (required) — Expects an `<ogds-primary-nav>`.
-- **`nav-secondary`** (optional) — Links and/or a search form. Aligned with the logo at desktop widths in the extended variant; folds into the drawer with the primary nav below the desktop breakpoint. The component consumer is responsible for the contents here and for implementing responsive behavior.
+- **`nav-secondary`** (optional) — Links and/or a search form. At desktop widths, this section aligns with the logo. At widths below the desktop breakpoint (e.g. mobile, tablet), this content folds into the drawer along with the primary nav. The component consumer is responsible for the contents here and for implementing responsive behavior.
 - **`notifications`** (optional) — Shown in the same row as the primary nav. It's called "notifications" but doesn't need to be that.
 - **`info`** (optional) — A banner/alert row between the navbar and the nav drawer.
 

--- a/src/components/ogds-header/index.ts
+++ b/src/components/ogds-header/index.ts
@@ -1,0 +1,2 @@
+export { OgdsHeader } from "./ogds-header";
+export type { OgdsHeaderVariant } from "./ogds-header";

--- a/src/components/ogds-header/ogds-header.css
+++ b/src/components/ogds-header/ogds-header.css
@@ -82,7 +82,7 @@
     background-color: var(--ogds-header-menu-btn-background-color-hover);
   }
 
-  &::before {
+  &.with-icon::before {
     background-color: currentColor;
     content: "";
     display: inline-block;

--- a/src/components/ogds-header/ogds-header.css
+++ b/src/components/ogds-header/ogds-header.css
@@ -14,15 +14,22 @@
   --ogds-header-nav-background-color: var(--ogds-color-white, #fff);
   --ogds-header-overlay-color: rgb(0 0 0 / 70%);
 
-  display: grid;
+  display: block;
   font-family: var(--ogds-header-font-family);
-  row-gap: var(--ogds-spacing-2, 1rem);
 }
 
 *,
 *::before,
 *::after {
   box-sizing: border-box;
+}
+
+.content {
+  display: grid;
+  margin-inline: auto;
+  max-width: var(--ogds-header-max-width, none);
+  padding-inline: var(--ogds-header-padding-inline, 0);
+  row-gap: var(--ogds-spacing-2, 1rem);
 }
 
 .navbar {
@@ -160,7 +167,7 @@
     translate: 0 0;
   }
 
-  .nav-secondary {
+  .nav-primary-row {
     border-block-start: 1px solid var(--ogds-header-divider-color);
     margin-block-start: var(--ogds-spacing-2, 1rem);
     padding-block-start: var(--ogds-spacing-2, 1rem);
@@ -207,20 +214,41 @@
 
   :host([variant="basic"]) .nav-primary-row {
     flex: 1 1 auto;
-  }
-
-  :host([variant="basic"]) .nav-secondary {
     margin-inline-start: var(--ogds-spacing-2, 1rem);
   }
 
-  :host([variant="extended"]) {
-    position: relative;
+  :host([variant="extended"]) .content {
+    grid-template-areas:
+      "navbar secondary"
+      "info info"
+      "primary primary";
+    grid-template-columns: 1fr auto;
+  }
+
+  :host([variant="extended"]) .navbar {
+    grid-area: navbar;
+  }
+
+  :host([variant="extended"]) .info {
+    border-block-end: none;
+    grid-area: info;
+  }
+
+  :host([variant="extended"]) .nav[open] {
+    display: contents;
+  }
+
+  :host([variant="extended"]) .nav-primary-row {
+    border-block-start: 1px solid var(--ogds-header-divider-color);
+    grid-area: primary;
   }
 
   :host([variant="extended"]) .nav-secondary {
-    inset-block-start: 0;
-    inset-inline-end: 0;
-    position: absolute;
+    align-items: flex-end;
+    align-self: start;
+    flex-direction: column;
+    grid-area: secondary;
+    justify-self: end;
   }
 }
 

--- a/src/components/ogds-header/ogds-header.css
+++ b/src/components/ogds-header/ogds-header.css
@@ -1,0 +1,229 @@
+:host {
+  --ogds-header-divider-color: var(--ogds-color-base-lighter, #dfe1e2);
+  --ogds-header-drawer-width: min(90vw, 21rem);
+  --ogds-header-font-family: system-ui, sans-serif;
+  --ogds-header-menu-btn-background-color: var(
+    --ogds-theme-color-primary,
+    #005ea2
+  );
+  --ogds-header-menu-btn-background-color-hover: var(
+    --ogds-theme-color-primary-dark,
+    #1a4480
+  );
+  --ogds-header-menu-btn-color: var(--ogds-color-white, #fff);
+  --ogds-header-nav-background-color: var(--ogds-color-white, #fff);
+  --ogds-header-overlay-color: rgb(0 0 0 / 70%);
+
+  display: grid;
+  font-family: var(--ogds-header-font-family);
+  row-gap: var(--ogds-spacing-2, 1rem);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+.navbar {
+  align-items: center;
+  display: flex;
+  gap: var(--ogds-spacing-2, 1rem);
+  justify-content: space-between;
+}
+
+.nav-primary-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ogds-spacing-2, 1rem);
+}
+
+.notifications {
+  align-items: center;
+  display: flex;
+  margin-inline-start: auto;
+}
+
+.info {
+  border-block: 1px solid var(--ogds-header-divider-color);
+  padding-block: var(--ogds-spacing-1, 0.5rem);
+}
+
+.menu-btn {
+  align-items: center;
+  background-color: var(--ogds-header-menu-btn-background-color);
+  border: none;
+  color: var(--ogds-header-menu-btn-color);
+  cursor: pointer;
+  display: none;
+  flex: none;
+  font: inherit;
+  font-weight: 700;
+  gap: var(--ogds-spacing-1, 0.5rem);
+  height: var(--ogds-size-touch-target, 2.5rem);
+  padding-inline: var(--ogds-spacing-2, 1rem);
+
+  &:hover {
+    background-color: var(--ogds-header-menu-btn-background-color-hover);
+  }
+
+  &::before {
+    background-color: currentColor;
+    content: "";
+    display: inline-block;
+    height: 1.25rem;
+    mask-image: var(--ogds-header-icon-menu);
+    mask-position: center;
+    mask-repeat: no-repeat;
+    mask-size: contain;
+    width: 1.25rem;
+  }
+}
+
+.nav-close {
+  align-self: flex-end;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  display: none;
+  flex: none;
+  height: var(--ogds-size-touch-target, 2.5rem);
+  width: var(--ogds-size-touch-target, 2.5rem);
+
+  &::before {
+    background-color: currentColor;
+    content: "";
+    display: block;
+    height: 1.5rem;
+    margin-inline: auto;
+    mask-image: var(--ogds-header-icon-close);
+    mask-position: center;
+    mask-repeat: no-repeat;
+    mask-size: contain;
+    width: 1.5rem;
+  }
+}
+
+.nav {
+  background-color: var(--ogds-header-nav-background-color);
+  border: none;
+  color: inherit;
+  margin: 0;
+  max-height: none;
+  max-width: none;
+  padding: var(--ogds-spacing-2, 1rem);
+
+  &.no-transition {
+    transition: none;
+  }
+
+  &::backdrop {
+    background: var(--ogds-header-overlay-color);
+  }
+
+  &[open] {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.nav-primary {
+  display: block;
+}
+
+.nav-secondary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ogds-spacing-1, 0.5rem);
+}
+
+@media (width < 64rem) {
+  .menu-btn {
+    display: inline-flex;
+  }
+
+  .nav-close {
+    display: block;
+  }
+
+  .nav {
+    height: 100%;
+    inset-block: 0;
+    inset-inline: auto 0;
+    position: fixed;
+    translate: 100% 0;
+    width: var(--ogds-header-drawer-width);
+  }
+
+  .nav[open] {
+    translate: 0 0;
+  }
+
+  .nav-secondary {
+    border-block-start: 1px solid var(--ogds-header-divider-color);
+    margin-block-start: var(--ogds-spacing-2, 1rem);
+    padding-block-start: var(--ogds-spacing-2, 1rem);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .nav {
+      transition:
+        translate 0.3s ease-in-out,
+        display 0.3s ease-in-out allow-discrete,
+        overlay 0.3s ease-in-out allow-discrete;
+    }
+
+    @starting-style {
+      .nav[open] {
+        translate: 100% 0;
+      }
+    }
+  }
+}
+
+@media (width >= 64rem) {
+  .nav {
+    padding: 0;
+    position: static;
+    width: 100%;
+  }
+
+  .nav-primary-row {
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .nav-secondary {
+    align-items: center;
+    flex-direction: row;
+  }
+
+  :host([variant="basic"]) .nav[open] {
+    align-items: center;
+    flex-direction: row;
+  }
+
+  :host([variant="basic"]) .nav-primary-row {
+    flex: 1 1 auto;
+  }
+
+  :host([variant="basic"]) .nav-secondary {
+    margin-inline-start: var(--ogds-spacing-2, 1rem);
+  }
+
+  :host([variant="extended"]) {
+    position: relative;
+  }
+
+  :host([variant="extended"]) .nav-secondary {
+    inset-block-start: 0;
+    inset-inline-end: 0;
+    position: absolute;
+  }
+}
+
+[hidden] {
+  display: none;
+}

--- a/src/components/ogds-header/ogds-header.css
+++ b/src/components/ogds-header/ogds-header.css
@@ -13,6 +13,7 @@
   --ogds-header-menu-btn-color: var(--ogds-color-white, #fff);
   --ogds-header-nav-background-color: var(--ogds-color-white, #fff);
   --ogds-header-overlay-color: rgb(0 0 0 / 70%);
+  --ogds-header-row-gap: var(--ogds-spacing-2, 1rem);
 
   display: block;
   font-family: var(--ogds-header-font-family);
@@ -29,17 +30,22 @@
   margin-inline: auto;
   max-width: var(--ogds-header-max-width, none);
   padding-inline: var(--ogds-header-padding-inline, 0);
-  row-gap: var(--ogds-spacing-2, 1rem);
+  row-gap: var(--ogds-header-row-gap);
 }
 
 .navbar {
   align-items: center;
+  background-color: var(--ogds-header-navbar-background-color, transparent);
   display: flex;
   gap: var(--ogds-spacing-2, 1rem);
   justify-content: space-between;
 }
 
 .nav-primary-row {
+  background-color: var(
+    --ogds-header-nav-primary-row-background-color,
+    transparent
+  );
   display: flex;
   flex-direction: column;
   gap: var(--ogds-spacing-2, 1rem);
@@ -52,8 +58,10 @@
 }
 
 .info {
+  background-color: var(--ogds-header-info-background-color, transparent);
   border-block: 1px solid var(--ogds-header-divider-color);
-  padding-block: var(--ogds-spacing-1, 0.5rem);
+  font-size: var(--ogds-theme-type-scale-2xs, 0.875rem);
+  padding-block: var(--ogds-spacing-05, 0.25rem);
 }
 
 .menu-btn {
@@ -140,6 +148,10 @@
 }
 
 .nav-secondary {
+  background-color: var(
+    --ogds-header-nav-secondary-background-color,
+    transparent
+  );
   display: flex;
   flex-direction: column;
   gap: var(--ogds-spacing-1, 0.5rem);
@@ -226,7 +238,9 @@
   }
 
   :host([variant="extended"]) .navbar {
+    align-self: center;
     grid-area: navbar;
+    padding-block: var(--ogds-spacing-3, 1.5rem);
   }
 
   :host([variant="extended"]) .info {
@@ -245,7 +259,7 @@
 
   :host([variant="extended"]) .nav-secondary {
     align-items: flex-end;
-    align-self: start;
+    align-self: center;
     flex-direction: column;
     grid-area: secondary;
     justify-self: end;

--- a/src/components/ogds-header/ogds-header.stories.ts
+++ b/src/components/ogds-header/ogds-header.stories.ts
@@ -1,0 +1,319 @@
+import { html } from "lit";
+import "./index";
+import "../ogds-primary-nav";
+import ComponentDocs from "./docs.mdx";
+
+const searchStyles = html`
+  <style>
+    .example-search {
+      display: flex;
+    }
+
+    .example-search input[type="search"] {
+      border: 1px solid var(--ogds-theme-color-base-dark);
+      border-radius: 0;
+      border-right: none;
+      font-family: var(--ogds-theme-button-font-family);
+      height: 2.5rem;
+      padding-inline: var(--ogds-spacing-1);
+    }
+
+    .example-search button {
+      background-color: var(--ogds-theme-button-fill-color);
+      border: none;
+      border-radius: 0 var(--ogds-theme-button-border-radius)
+        var(--ogds-theme-button-border-radius) 0;
+      color: var(--ogds-theme-button-text-color);
+      cursor: pointer;
+      font-family: var(--ogds-theme-button-font-family);
+      font-weight: 700;
+      height: 2.5rem;
+      padding-inline: var(--ogds-spacing-105);
+    }
+
+    .example-search button:hover {
+      background-color: var(--ogds-theme-color-primary-dark);
+    }
+  </style>
+`;
+
+const secondaryLinksStyles = html`
+  <style>
+    .example-secondary-links {
+      display: flex;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    .example-secondary-links li + li {
+      border-inline-start: 1px solid var(--ogds-theme-color-base-lighter);
+      margin-inline-start: var(--ogds-spacing-1);
+      padding-inline-start: var(--ogds-spacing-1);
+    }
+
+    .example-secondary-links a {
+      color: var(--ogds-theme-color-base);
+      font-family: var(--ogds-theme-button-font-family);
+      font-size: var(--ogds-theme-type-scale-2xs);
+      text-decoration: none;
+    }
+
+    .example-secondary-links a:hover {
+      color: var(--ogds-theme-color-primary);
+      text-decoration: underline;
+    }
+  </style>
+`;
+
+const genericPrimaryNav = html`
+  <ogds-primary-nav slot="nav-primary">
+    <ul>
+      <li><a href="#" aria-current="page">Current section</a></li>
+      <li>
+        <details>
+          <summary>Benefits</summary>
+          <ul>
+            <li><a href="#">Navigation link</a></li>
+            <li><a href="#">Navigation link</a></li>
+            <li><a href="#">Navigation link</a></li>
+            <li><a href="#">Navigation link</a></li>
+          </ul>
+        </details>
+      </li>
+      <li>
+        <details>
+          <summary>Resources</summary>
+          <ul>
+            <li><a href="#">Navigation link</a></li>
+            <li><a href="#">Navigation link</a></li>
+            <li><a href="#">Navigation link</a></li>
+          </ul>
+        </details>
+      </li>
+      <li><a href="#">Simple link</a></li>
+    </ul>
+  </ogds-primary-nav>
+`;
+
+const genericSearch = html`
+  <form class="example-search" slot="nav-secondary" role="search">
+    <input type="search" aria-label="Search" name="q" />
+    <button type="submit">Search</button>
+  </form>
+`;
+
+export default {
+  title: "Components/Header",
+  component: "ogds-header",
+  tags: ["experimental"],
+  parameters: {
+    docs: {
+      page: ComponentDocs,
+    },
+  },
+};
+
+export const Extended = {
+  render: () => html`
+    ${searchStyles} ${secondaryLinksStyles}
+    <ogds-header variant="extended">
+      <div slot="logo"><a href="/">Project name</a></div>
+      <div slot="notifications">Notifications</div>
+      <div slot="info">Alert or banner content goes here.</div>
+      <ul class="example-secondary-links" slot="nav-secondary">
+        <li><a href="#">Secondary link</a></li>
+        <li><a href="#">Another secondary link</a></li>
+      </ul>
+      ${genericSearch} ${genericPrimaryNav}
+    </ogds-header>
+  `,
+};
+
+export const Basic = {
+  render: () => html`
+    ${searchStyles}
+    <ogds-header variant="basic">
+      <div slot="logo"><a href="/">Project name</a></div>
+      ${genericSearch} ${genericPrimaryNav}
+    </ogds-header>
+  `,
+};
+
+export const MarylandFAMLIExample = {
+  name: "Maryland FAMLI example (paidleave.maryland.gov)",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Configuring `ogds-header` to reproduce the production header at [paidleave.maryland.gov](https://paidleave.maryland.gov/): a logo image, a primary nav with real section links (some with dropdowns, some without), and a secondary nav holding a registration CTA, a language link, and search.",
+      },
+    },
+  },
+  render: () => html`
+    <style>
+      .famli-register-button {
+        border-radius: var(--ogds-theme-button-border-radius);
+        box-shadow: inset 0 0 0 var(--ogds-theme-button-stroke-width)
+          var(--ogds-theme-button-stroke-color);
+        color: var(--ogds-theme-button-stroke-color);
+        display: inline-flex;
+        font-family: var(--ogds-theme-button-font-family);
+        font-weight: 700;
+        padding: var(--ogds-spacing-105) var(--ogds-spacing-205);
+        text-decoration: none;
+      }
+
+      .famli-register-button:hover {
+        box-shadow: inset 0 0 0 var(--ogds-theme-button-stroke-width)
+          var(--ogds-theme-color-primary-dark);
+        color: var(--ogds-theme-color-primary-dark);
+      }
+
+      .famli-button-group {
+        display: flex;
+        gap: var(--ogds-spacing-1);
+      }
+
+      .famli-language-button {
+        background-color: var(--ogds-theme-button-fill-color);
+        border-radius: var(--ogds-theme-button-border-radius);
+        color: var(--ogds-theme-button-text-color);
+        display: inline-flex;
+        font-family: var(--ogds-theme-button-font-family);
+        font-weight: 700;
+        padding: var(--ogds-spacing-105) var(--ogds-spacing-205);
+        text-decoration: none;
+      }
+
+      .famli-language-button:hover {
+        background-color: var(--ogds-theme-color-primary-dark);
+      }
+
+      .famli-sr-only {
+        border: 0;
+        clip: rect(0, 0, 0, 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        white-space: nowrap;
+        width: 1px;
+      }
+
+      .famli-search {
+        display: flex;
+      }
+
+      .famli-search input[type="search"] {
+        border: 1px solid var(--ogds-theme-color-base-dark);
+        border-radius: 0;
+        border-right: none;
+        font-family: var(--ogds-theme-button-font-family);
+        height: 2.5rem;
+        padding-inline: var(--ogds-spacing-1);
+      }
+
+      .famli-search button {
+        background-color: var(--ogds-theme-button-fill-color);
+        border: none;
+        border-radius: 0 var(--ogds-theme-button-border-radius)
+          var(--ogds-theme-button-border-radius) 0;
+        color: var(--ogds-theme-button-text-color);
+        cursor: pointer;
+        font-family: var(--ogds-theme-button-font-family);
+        font-weight: 700;
+        height: 2.5rem;
+        padding-inline: var(--ogds-spacing-105);
+      }
+
+      .famli-search button:hover {
+        background-color: var(--ogds-theme-color-primary-dark);
+      }
+    </style>
+
+    <ogds-header variant="extended">
+      <a slot="logo" href="/">
+        <img
+          src="https://paidleave.maryland.gov/img/OsA2lxQa9u-400.webp"
+          alt="Maryland FAMLI, Family and Medical Leave Insurance"
+          height="49"
+        />
+      </a>
+
+      <div class="famli-button-group" slot="nav-secondary">
+        <a
+          class="famli-register-button"
+          href="https://account.paidleave.maryland.gov/"
+          >Register with FAMLI or sign in</a
+        >
+        <a
+          class="famli-language-button"
+          href="https://translate.google.com/translate?u=https://paidleave.maryland.gov/"
+          >Languages</a
+        >
+      </div>
+      <form class="famli-search" slot="nav-secondary" role="search">
+        <label class="famli-sr-only" for="famli-search">Search</label>
+        <input id="famli-search" type="search" name="q" />
+        <button type="submit">Search</button>
+      </form>
+
+      <ogds-primary-nav slot="nav-primary">
+        <ul>
+          <li>
+            <details>
+              <summary>About the program</summary>
+              <ul>
+                <li><a href="/about-the-program/">About the program</a></li>
+                <li>
+                  <a href="/about-the-program/law-and-regulations/"
+                    >Law and regulations</a
+                  >
+                </li>
+              </ul>
+            </details>
+          </li>
+          <li>
+            <details>
+              <summary>For employers</summary>
+              <ul>
+                <li>
+                  <a href="/employers/understand-employer-registration/"
+                    >Understand employer registration</a
+                  >
+                </li>
+                <li>
+                  <a href="/employers/manage-famli-for-clients/"
+                    >Manage FAMLI for clients</a
+                  >
+                </li>
+                <li>
+                  <a href="/employers/understand-your-plan/"
+                    >Understand your plan</a
+                  >
+                </li>
+                <li>
+                  <a href="/employers/submit-quarterly-reports/"
+                    >Submit quarterly reports</a
+                  >
+                </li>
+                <li>
+                  <a href="/employers/make-contributions/"
+                    >Make contributions</a
+                  >
+                </li>
+                <li>
+                  <a href="/employers/leave-management/">Leave management</a>
+                </li>
+              </ul>
+            </details>
+          </li>
+          <li><a href="/employees/" aria-current="page">For employees</a></li>
+          <li><a href="/connect-with-us/">Connect with us</a></li>
+        </ul>
+      </ogds-primary-nav>
+    </ogds-header>
+  `,
+};

--- a/src/components/ogds-header/ogds-header.stories.ts
+++ b/src/components/ogds-header/ogds-header.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import "./index";
 import "../ogds-primary-nav";
+import "../ogds-accordion";
 import ComponentDocs from "./docs.mdx";
 
 const searchStyles = html`
@@ -120,7 +121,6 @@ export const Extended = {
     <ogds-header variant="extended">
       <div slot="logo"><a href="/">Project name</a></div>
       <div slot="notifications">Notifications</div>
-      <div slot="info">Alert or banner content goes here.</div>
       <ul class="example-secondary-links" slot="nav-secondary">
         <li><a href="#">Secondary link</a></li>
         <li><a href="#">Another secondary link</a></li>
@@ -136,6 +136,64 @@ export const Basic = {
     <ogds-header variant="basic">
       <div slot="logo"><a href="/">Project name</a></div>
       ${genericSearch} ${genericPrimaryNav}
+    </ogds-header>
+  `,
+};
+
+export const EmpXExample = {
+  name: "State agency header with info section",
+  render: () => html`
+    <style>
+      .state-with-info-example {
+        --ogds-header-nav-primary-row-background-color: #fff;
+        background-color: var(--ogds-theme-color-base-lightest);
+
+        ogds-accordion details[open]::details-content {
+          position: absolute;
+          background-color: var(--ogds-theme-color-base-lightest);
+        }
+
+        [slot="info"] {
+          padding: 0.5rem 0;
+        }
+      }
+
+      @media (width >= 64rem) {
+        .state-with-info-example {
+          --ogds-header-row-gap: 0;
+        }
+      }
+    </style>
+    <ogds-header variant="extended" class="state-with-info-example">
+      <a slot="logo" href="/">
+        <img
+          src="https://paidleave.maryland.gov/img/OsA2lxQa9u-400.webp"
+          alt="Maryland FAMLI, Family and Medical Leave Insurance"
+          height="49"
+        />
+      </a>
+      <div slot="info">
+        <strong>Employer:</strong> Bagels Bagels Bagels (44-1112222)
+      </div>
+      <ogds-accordion slot="nav-secondary" class="with-icon right">
+        <details>
+          <summary>Signed in as A Person</summary>
+          <ul>
+            <li><a href="javascript:void(0)">Home</a></li>
+            <li><a href="javascript:void(0)">Clients</a></li>
+            <li><a href="javascript:void(0)">Reports & payments</a></li>
+          </ul>
+        </details>
+      </ogds-accordion>
+      <ogds-primary-nav slot="nav-primary">
+        <ul>
+          <li><a href="javascript:void(0)">Home</a></li>
+          <li><a href="javascript:void(0)">Clients</a></li>
+          <li><a href="javascript:void(0)">Reports & payments</a></li>
+          <li><a href="javascript:void(0)">Employer details</a></li>
+          <li><a href="javascript:void(0)">Team members</a></li>
+        </ul>
+      </ogds-primary-nav>
     </ogds-header>
   `,
 };
@@ -231,9 +289,21 @@ export const MarylandFAMLIExample = {
       .famli-search button:hover {
         background-color: var(--ogds-theme-color-primary-dark);
       }
+
+      .logged-out-example {
+        background-color: var(--ogds-theme-color-base-lightest);
+        --ogds-header-nav-primary-row-background-color: #fff;
+        --ogds-header-row-gap: 0;
+
+        [slot="logo"] {
+          display: flex;
+          min-height: 6rem;
+          align-items: center;
+        }
+      }
     </style>
 
-    <ogds-header variant="extended">
+    <ogds-header variant="extended" class="logged-out-example">
       <a slot="logo" href="/">
         <img
           src="https://paidleave.maryland.gov/img/OsA2lxQa9u-400.webp"
@@ -243,16 +313,10 @@ export const MarylandFAMLIExample = {
       </a>
 
       <div class="famli-button-group" slot="nav-secondary">
-        <a
-          class="famli-register-button"
-          href="https://account.paidleave.maryland.gov/"
+        <a class="famli-register-button" href="javascript:void(0)"
           >Register with FAMLI or sign in</a
         >
-        <a
-          class="famli-language-button"
-          href="https://translate.google.com/translate?u=https://paidleave.maryland.gov/"
-          >Languages</a
-        >
+        <a class="famli-language-button" href="javascript:void(0)">Languages</a>
       </div>
       <form class="famli-search" slot="nav-secondary" role="search">
         <label class="famli-sr-only" for="famli-search">Search</label>
@@ -312,6 +376,120 @@ export const MarylandFAMLIExample = {
           </li>
           <li><a href="/employees/" aria-current="page">For employees</a></li>
           <li><a href="/connect-with-us/">Connect with us</a></li>
+        </ul>
+      </ogds-primary-nav>
+    </ogds-header>
+  `,
+};
+
+export const WorkerXExample = {
+  name: "State agency example with notifications",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Configuring `ogds-header` to reproduce a state agency header with an account status & search in the secondary nav area, a notification count in the notifications slot, and an `ogds-primary-nav` with several dropdown sections.",
+      },
+    },
+  },
+  render: () => html`
+    ${searchStyles}
+    <style>
+      .example-workerx-header {
+        background-color: var(--ogds-theme-color-base-lightest);
+        --ogds-header-row-gap: 0;
+      }
+
+      .example-account {
+        color: var(--ogds-theme-text-color);
+        font-family: var(--ogds-theme-button-font-family);
+        font-size: var(--ogds-theme-type-scale-2xs);
+      }
+
+      .example-notification-badge {
+        align-items: center;
+        background-color: var(--ogds-theme-color-secondary);
+        border-radius: 50%;
+        color: var(--ogds-color-white, #fff);
+        display: inline-flex;
+        font-size: var(--ogds-theme-type-scale-3xs);
+        font-weight: 700;
+        height: 1.25rem;
+        justify-content: center;
+        margin-inline-start: var(--ogds-spacing-05, 0.25rem);
+        width: 1.25rem;
+      }
+    </style>
+
+    <ogds-header class="example-workerx-header" variant="extended">
+      <a slot="logo" href="/">
+        <img
+          src="https://paidleave.maryland.gov/img/OsA2lxQa9u-400.webp"
+          alt="Maryland FAMLI, Family and Medical Leave Insurance"
+          height="49"
+        />
+      </a>
+
+      <div slot="notifications">
+        Notifications
+        <span class="example-notification-badge">10</span>
+      </div>
+
+      ${genericSearch}
+      <div class="example-account" slot="nav-secondary">
+        Signed in as <strong>Mindy</strong>
+      </div>
+
+      <ogds-primary-nav slot="nav-primary">
+        <ul>
+          <li><a href="#">Home</a></li>
+          <li>
+            <details open>
+              <summary>Claims Center</summary>
+              <ul>
+                <li><a href="#">File a new claim</a></li>
+                <li><a href="#">Track my claims</a></li>
+                <li><a href="#" aria-current="page">Manage my claims</a></li>
+                <li><a href="#">FAMLI forms and documents</a></li>
+              </ul>
+            </details>
+          </li>
+          <li>
+            <details>
+              <summary>Leave Center</summary>
+              <ul>
+                <li><a href="#">Navigation link</a></li>
+                <li><a href="#">Navigation link</a></li>
+              </ul>
+            </details>
+          </li>
+          <li>
+            <details>
+              <summary>Notices &amp; tax forms</summary>
+              <ul>
+                <li><a href="#">Navigation link</a></li>
+                <li><a href="#">Navigation link</a></li>
+              </ul>
+            </details>
+          </li>
+          <li>
+            <details>
+              <summary>Appeals Center</summary>
+              <ul>
+                <li><a href="#">Navigation link</a></li>
+                <li><a href="#">Navigation link</a></li>
+              </ul>
+            </details>
+          </li>
+          <li>
+            <details>
+              <summary>Support</summary>
+              <ul>
+                <li><a href="#">Navigation link</a></li>
+                <li><a href="#">Navigation link</a></li>
+              </ul>
+            </details>
+          </li>
         </ul>
       </ogds-primary-nav>
     </ogds-header>

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -21,6 +21,10 @@ export type OgdsHeaderVariant = "basic" | "extended";
  * @slot notifications - Optional. Content like an account or notifications indicator shown alongside the primary nav.
  * @slot nav-secondary - Optional. Secondary links and/or a search form. At desktop widths (extended variant), shown aligned with the logo; below the desktop breakpoint it folds into the drawer with the primary nav.
  *
+ * @cssprop --ogds-header-navbar-background-color - Background color of the navbar row (logo + menu button). Transparent by default.
+ * @cssprop --ogds-header-info-background-color - Background color of the info row. Transparent by default.
+ * @cssprop --ogds-header-nav-primary-row-background-color - Background color of the row containing the primary nav and notifications. Transparent by default.
+ * @cssprop --ogds-header-nav-secondary-background-color - Background color of the secondary nav area. Transparent by default.
  * @cssprop --ogds-header-menu-btn-background-color - Background color of the menu button.
  * @cssprop --ogds-header-menu-btn-color - Text/icon color of the menu button.
  * @cssprop --ogds-header-nav-background-color - Background color of the navigation drawer.
@@ -29,6 +33,7 @@ export type OgdsHeaderVariant = "basic" | "extended";
  * @cssprop --ogds-header-drawer-width - Width of the navigation drawer below the desktop breakpoint.
  * @cssprop --ogds-header-max-width - Max width of the header's content, centered with auto margins (like a USWDS grid container). Unset by default, so content spans the full width of the host.
  * @cssprop --ogds-header-padding-inline - Horizontal gutter applied alongside --ogds-header-max-width. Unset by default.
+ * @cssprop --ogds-header-row-gap - Vertical gap between the rows of the header grid (logo/secondary nav, info, and primary nav).
  *
  * @element ogds-header
  */

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -1,0 +1,178 @@
+import { LitElement, css, html, unsafeCSS } from "lit";
+import { property } from "lit/decorators.js";
+
+import styles from "./ogds-header.css";
+import iconMenu from "../../shared/icons/menu.svg";
+import iconClose from "../../shared/icons/close.svg";
+
+import { adoptTokenStyles } from "../../core/token-styles";
+import { defineCustomElement } from "../../utils";
+
+const DESKTOP_QUERY = "(width >= 64rem)";
+
+export type OgdsHeaderVariant = "basic" | "extended";
+
+/**
+ * @summary A responsive site header, styled to match the USWDS basic and extended header patterns.
+ *
+ * @slot logo - The site logo/wordmark, typically a link to the homepage.
+ * @slot info - Optional. A banner/alert row shown between the navbar and the navigation drawer.
+ * @slot nav-primary - Expects an `<ogds-primary-nav>` with the site's primary section links.
+ * @slot notifications - Optional. Content (e.g. an account or notifications indicator) shown alongside the primary nav.
+ * @slot nav-secondary - Optional. Secondary links and/or a search form. At desktop widths (extended variant), shown aligned with the logo; below the desktop breakpoint it folds into the drawer with the primary nav.
+ *
+ * @cssprop --ogds-header-menu-btn-background-color - Background color of the menu button.
+ * @cssprop --ogds-header-menu-btn-color - Text/icon color of the menu button.
+ * @cssprop --ogds-header-nav-background-color - Background color of the navigation drawer.
+ * @cssprop --ogds-header-overlay-color - Color of the backdrop behind the open drawer.
+ * @cssprop --ogds-header-divider-color - Color of hairline dividers.
+ * @cssprop --ogds-header-drawer-width - Width of the navigation drawer below the desktop breakpoint.
+ *
+ * @element ogds-header
+ */
+export class OgdsHeader extends LitElement {
+  @property({ reflect: true }) variant: OgdsHeaderVariant = "extended";
+
+  private _desktopQuery: MediaQueryList | null = null;
+  private _navDialog: HTMLDialogElement | null = null;
+  private _menuBtn: HTMLButtonElement | null = null;
+
+  static styles = [
+    css`
+      :host {
+        --ogds-header-icon-close: url("${unsafeCSS(iconClose)}");
+        --ogds-header-icon-menu: url("${unsafeCSS(iconMenu)}");
+      }
+    `,
+    styles,
+  ];
+
+  override connectedCallback() {
+    super.connectedCallback();
+    adoptTokenStyles();
+
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "banner");
+    }
+
+    if (typeof matchMedia === "function") {
+      this._desktopQuery = matchMedia(DESKTOP_QUERY);
+      this._desktopQuery.addEventListener("change", this._onViewportChange);
+    }
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this._desktopQuery?.removeEventListener("change", this._onViewportChange);
+  }
+
+  override firstUpdated() {
+    this._navDialog = this.renderRoot.querySelector("dialog");
+    this._menuBtn = this.renderRoot.querySelector(".menu-btn");
+    this._syncNavToViewport();
+  }
+
+  private _isDesktop() {
+    return this._desktopQuery?.matches ?? true;
+  }
+
+  private _onViewportChange = () => this._syncNavToViewport();
+
+  private _syncNavToViewport() {
+    const dialog = this._navDialog;
+    if (!dialog) return;
+
+    if (this._isDesktop()) {
+      if (dialog.open && dialog.matches(":modal")) {
+        dialog.close();
+      }
+      if (!dialog.open) {
+        dialog.show();
+      }
+      this._menuBtn?.setAttribute("aria-expanded", "false");
+    } else if (dialog.open && !dialog.matches(":modal")) {
+      dialog.classList.add("no-transition");
+      dialog.close();
+      requestAnimationFrame(() => dialog.classList.remove("no-transition"));
+    }
+  }
+
+  private _onMenuBtnClick() {
+    this._navDialog?.showModal();
+    this._menuBtn?.setAttribute("aria-expanded", "true");
+  }
+
+  private _onCloseBtnClick() {
+    this._navDialog?.close();
+  }
+
+  private _onDialogClose() {
+    if (this._isDesktop()) return;
+    this._menuBtn?.setAttribute("aria-expanded", "false");
+  }
+
+  /** Clicking the backdrop (outside the drawer's own box) closes it, like clicking the USWDS overlay. */
+  private _onDialogClick(event: MouseEvent) {
+    if (event.target === this._navDialog) {
+      this._navDialog?.close();
+    }
+  }
+
+  private _onOptionalSlotChange(event: Event) {
+    const slot = event.target as HTMLSlotElement;
+    const wrapper = slot.parentElement;
+    if (!wrapper) return;
+    wrapper.hidden = slot.assignedNodes({ flatten: true }).length === 0;
+  }
+
+  render() {
+    return html`
+      <div class="navbar">
+        <div class="logo"><slot name="logo"></slot></div>
+        <button
+          type="button"
+          class="menu-btn"
+          aria-controls="nav"
+          aria-expanded="false"
+          @click=${this._onMenuBtnClick}
+        >
+          Menu
+        </button>
+      </div>
+      <div class="info" hidden>
+        <slot name="info" @slotchange=${this._onOptionalSlotChange}></slot>
+      </div>
+      <dialog
+        id="nav"
+        class="nav"
+        aria-label="Header navigation"
+        @close=${this._onDialogClose}
+        @click=${this._onDialogClick}
+      >
+        <button
+          type="button"
+          class="nav-close"
+          aria-label="Close menu"
+          @click=${this._onCloseBtnClick}
+        ></button>
+        <div class="nav-primary-row">
+          <div class="nav-primary"><slot name="nav-primary"></slot></div>
+          <div class="notifications" hidden>
+            <slot
+              name="notifications"
+              @slotchange=${this._onOptionalSlotChange}
+            ></slot>
+          </div>
+        </div>
+        <nav class="nav-secondary" aria-label="Secondary navigation">
+          <slot
+            name="nav-secondary"
+            @slotchange=${this._onOptionalSlotChange}
+          ></slot>
+        </nav>
+      </dialog>
+    `;
+  }
+}
+
+defineCustomElement("ogds-header", OgdsHeader);

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -17,24 +17,29 @@ export type OgdsHeaderVariant = "basic" | "extended";
  *
  * @slot logo - The site logo/wordmark, typically a link to the homepage.
  * @slot info - Optional. A banner/alert row shown between the navbar and the navigation drawer.
- * @slot nav-primary - Expects an `<ogds-primary-nav>` with the site's primary section links.
- * @slot notifications - Optional. Content (e.g. an account or notifications indicator) shown alongside the primary nav.
+ * @slot nav-primary - Expects an `<ogds-primary-nav>` with the site's primary section links, or some other primary nav implementation.
+ * @slot notifications - Optional. Content like an account or notifications indicator shown alongside the primary nav.
  * @slot nav-secondary - Optional. Secondary links and/or a search form. At desktop widths (extended variant), shown aligned with the logo; below the desktop breakpoint it folds into the drawer with the primary nav.
  *
  * @cssprop --ogds-header-menu-btn-background-color - Background color of the menu button.
  * @cssprop --ogds-header-menu-btn-color - Text/icon color of the menu button.
  * @cssprop --ogds-header-nav-background-color - Background color of the navigation drawer.
  * @cssprop --ogds-header-overlay-color - Color of the backdrop behind the open drawer.
- * @cssprop --ogds-header-divider-color - Color of hairline dividers.
+ * @cssprop --ogds-header-divider-color - Color of hairline dividers/borders.
  * @cssprop --ogds-header-drawer-width - Width of the navigation drawer below the desktop breakpoint.
+ * @cssprop --ogds-header-max-width - Max width of the header's content, centered with auto margins (like a USWDS grid container). Unset by default, so content spans the full width of the host.
+ * @cssprop --ogds-header-padding-inline - Horizontal gutter applied alongside --ogds-header-max-width. Unset by default.
  *
  * @element ogds-header
  */
 export class OgdsHeader extends LitElement {
   @property({ reflect: true }) variant: OgdsHeaderVariant = "extended";
 
+  /** @ignore */
   private _desktopQuery: MediaQueryList | null = null;
+  /** @ignore */
   private _navDialog: HTMLDialogElement | null = null;
+  /** @ignore */
   private _menuBtn: HTMLButtonElement | null = null;
 
   static styles = [
@@ -72,12 +77,15 @@ export class OgdsHeader extends LitElement {
     this._syncNavToViewport();
   }
 
+  /** @ignore */
   private _isDesktop() {
     return this._desktopQuery?.matches ?? true;
   }
 
+  /** @ignore */
   private _onViewportChange = () => this._syncNavToViewport();
 
+  /** @ignore */
   private _syncNavToViewport() {
     const dialog = this._navDialog;
     if (!dialog) return;
@@ -97,27 +105,33 @@ export class OgdsHeader extends LitElement {
     }
   }
 
+  /** @ignore */
   private _onMenuBtnClick() {
     this._navDialog?.showModal();
     this._menuBtn?.setAttribute("aria-expanded", "true");
   }
 
+  /** @ignore */
   private _onCloseBtnClick() {
     this._navDialog?.close();
   }
 
+  /** @ignore */
   private _onDialogClose() {
     if (this._isDesktop()) return;
     this._menuBtn?.setAttribute("aria-expanded", "false");
   }
 
-  /** Clicking the backdrop (outside the drawer's own box) closes it, like clicking the USWDS overlay. */
+  /**
+   * @ignore
+   */
   private _onDialogClick(event: MouseEvent) {
     if (event.target === this._navDialog) {
       this._navDialog?.close();
     }
   }
 
+  /** @ignore */
   private _onOptionalSlotChange(event: Event) {
     const slot = event.target as HTMLSlotElement;
     const wrapper = slot.parentElement;
@@ -127,50 +141,52 @@ export class OgdsHeader extends LitElement {
 
   render() {
     return html`
-      <div class="navbar">
-        <div class="logo"><slot name="logo"></slot></div>
-        <button
-          type="button"
-          class="menu-btn"
-          aria-controls="nav"
-          aria-expanded="false"
-          @click=${this._onMenuBtnClick}
+      <div class="content">
+        <div class="navbar">
+          <div class="logo"><slot name="logo"></slot></div>
+          <button
+            type="button"
+            class="menu-btn"
+            aria-controls="nav"
+            aria-expanded="false"
+            @click=${this._onMenuBtnClick}
+          >
+            Menu
+          </button>
+        </div>
+        <div class="info" hidden>
+          <slot name="info" @slotchange=${this._onOptionalSlotChange}></slot>
+        </div>
+        <dialog
+          id="nav"
+          class="nav"
+          aria-label="Header navigation"
+          @close=${this._onDialogClose}
+          @click=${this._onDialogClick}
         >
-          Menu
-        </button>
-      </div>
-      <div class="info" hidden>
-        <slot name="info" @slotchange=${this._onOptionalSlotChange}></slot>
-      </div>
-      <dialog
-        id="nav"
-        class="nav"
-        aria-label="Header navigation"
-        @close=${this._onDialogClose}
-        @click=${this._onDialogClick}
-      >
-        <button
-          type="button"
-          class="nav-close"
-          aria-label="Close menu"
-          @click=${this._onCloseBtnClick}
-        ></button>
-        <div class="nav-primary-row">
-          <div class="nav-primary"><slot name="nav-primary"></slot></div>
-          <div class="notifications" hidden>
+          <button
+            type="button"
+            class="nav-close"
+            aria-label="Close menu"
+            @click=${this._onCloseBtnClick}
+          ></button>
+          <nav class="nav-secondary" aria-label="Secondary navigation">
             <slot
-              name="notifications"
+              name="nav-secondary"
               @slotchange=${this._onOptionalSlotChange}
             ></slot>
+          </nav>
+          <div class="nav-primary-row">
+            <div class="nav-primary"><slot name="nav-primary"></slot></div>
+            <div class="notifications" hidden>
+              <slot
+                name="notifications"
+                @slotchange=${this._onOptionalSlotChange}
+              ></slot>
+            </div>
           </div>
-        </div>
-        <nav class="nav-secondary" aria-label="Secondary navigation">
-          <slot
-            name="nav-secondary"
-            @slotchange=${this._onOptionalSlotChange}
-          ></slot>
-        </nav>
-      </dialog>
+        </dialog>
+      </div>
     `;
   }
 }


### PR DESCRIPTION
# Summary

Added a new `ogds-header` component that will make it easier implement USWDS-like layouts and responsive behavior.

## Preview link

Storybook preview in comments below

## Problem statement

Multiple teams at MD Labor have similar but distinct USWDS-like header designs. Building a single component that those teams can share while adding their own customizations cuts down on maintenance and support, and ensures that it is easy to get updates.

## Solution

This component is a shell with several slots, meant to make it straightforward to share the main layout and responsive behavior while still allowing full control and customization of the content that goes into those slots. The mobile menu uses a native `<dialog>` element for better accessibility out-of-the-box with less manual ARIA, focus-trapping, and keyboard-only support. Other than handling transitions between mobile & desktop behaviors for the nav, there is very little logic in the component.

## Major changes

- `<dialog>` as mentioned above for the mobile drawer
- The main layout uses shadow DOM but has several custom properties for style needs that arose when building the sample stories
- Light DOM slots allow for finer-grained control of details that will be specific to particular use cases (search field behavior, secondary nav, account info, notifications, etc.).
- One major change from the USWDS implementation is that this version uses a different source order that supports a more natural tab order (left -> right, top -> down rather than top -> down -> up -> right -> down)

## Testing and review

- Review the storybook and let me know if the API surface for the component makes sense. 
- Are there use cases this component should handle that it currently doesn't?
