### PR TITLE
Add header tests

### DIFF
--- a/e2e/components/ogds-header/ogds-header.spec.ts
+++ b/e2e/components/ogds-header/ogds-header.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+import { StorybookPage } from "../../models/storybook-page";
+
+test.describe("ogds-header menu drawer", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+    const storybookPage = new StorybookPage(page);
+    await storybookPage.gotoAndWaitForDomLoaded("components-header--extended");
+  });
+
+  test("opens and closes the drawer via the menu and close buttons", async ({
+    page,
+  }) => {
+    const menuButton = page.getByRole("button", {
+      name: "Menu",
+      exact: true,
+    });
+    const primaryNavLink = page.getByRole("link", { name: "Current section" });
+
+    await expect(primaryNavLink).not.toBeVisible();
+
+    await menuButton.click();
+    await expect(primaryNavLink).toBeVisible();
+    await expect(menuButton).toHaveAttribute("aria-expanded", "true");
+
+    await page.getByRole("button", { name: "Close menu" }).click();
+    await expect(primaryNavLink).not.toBeVisible();
+    await expect(menuButton).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("can be reopened after closing", async ({ page }) => {
+    const menuButton = page.getByRole("button", {
+      name: "Menu",
+      exact: true,
+    });
+    const primaryNavLink = page.getByRole("link", { name: "Current section" });
+
+    await menuButton.click();
+    await page.getByRole("button", { name: "Close menu" }).click();
+    await menuButton.click();
+
+    await expect(primaryNavLink).toBeVisible();
+  });
+});

--- a/src/components/ogds-header/ogds-header.css
+++ b/src/components/ogds-header/ogds-header.css
@@ -2,6 +2,8 @@
   --ogds-header-divider-color: var(--ogds-color-base-lighter, #dfe1e2);
   --ogds-header-drawer-width: min(90vw, 21rem);
   --ogds-header-font-family: system-ui, sans-serif;
+  --ogds-header-icon-close-size: 1.5rem;
+  --ogds-header-icon-menu-size: 1.25rem;
   --ogds-header-menu-btn-background-color: var(
     --ogds-theme-color-primary,
     #005ea2
@@ -86,12 +88,12 @@
     background-color: currentColor;
     content: "";
     display: inline-block;
-    height: 1.25rem;
+    height: var(--ogds-header-icon-menu-size);
     mask-image: var(--ogds-header-icon-menu);
     mask-position: center;
     mask-repeat: no-repeat;
     mask-size: contain;
-    width: 1.25rem;
+    width: var(--ogds-header-icon-menu-size);
   }
 }
 
@@ -110,13 +112,13 @@
     background-color: currentColor;
     content: "";
     display: block;
-    height: 1.5rem;
+    height: var(--ogds-header-icon-close-size);
     margin-inline: auto;
     mask-image: var(--ogds-header-icon-close);
     mask-position: center;
     mask-repeat: no-repeat;
     mask-size: contain;
-    width: 1.5rem;
+    width: var(--ogds-header-icon-close-size);
   }
 }
 

--- a/src/components/ogds-header/ogds-header.spec.ts
+++ b/src/components/ogds-header/ogds-header.spec.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("./ogds-header.css", () => ({ default: { cssText: "" } }));
+vi.mock("../../shared/icons/menu.svg", () => ({ default: "" }));
+vi.mock("../../shared/icons/close.svg", () => ({ default: "" }));
+vi.mock("../../core/token-styles", () => ({ adoptTokenStyles: vi.fn() }));
+
+import { OgdsHeader } from "./ogds-header";
+
+/**
+ * jsdom doesn't implement the imperative <dialog> API at all, so polyfill
+ * just enough of it (open state, the close event, and :modal matching) for
+ * the component's viewport-sync logic to run without throwing.
+ *
+ * Tracking issue for this, which is also where the polyfill idea came from
+ * https://github.com/jsdom/jsdom/issues/3294
+ *
+ * TODO: See if there are alternatives for Jsdom that don't have this issue
+ * (that issue is really old which isn't a good signal)
+ */
+const modalDialogs = new WeakSet<HTMLDialogElement>();
+const originalMatches = HTMLDialogElement.prototype.matches;
+
+HTMLDialogElement.prototype.show = function (this: HTMLDialogElement) {
+  if (this.open) return;
+  this.open = true;
+  modalDialogs.delete(this);
+};
+HTMLDialogElement.prototype.showModal = function (this: HTMLDialogElement) {
+  if (this.open) {
+    throw new DOMException(
+      "Failed to execute 'showModal' on 'HTMLDialogElement': The element already has an 'open' attribute, and therefore cannot be opened modally.",
+      "InvalidStateError",
+    );
+  }
+  this.open = true;
+  modalDialogs.add(this);
+};
+HTMLDialogElement.prototype.close = function (this: HTMLDialogElement) {
+  if (!this.open) return;
+  this.open = false;
+  modalDialogs.delete(this);
+  this.dispatchEvent(new Event("close"));
+};
+HTMLDialogElement.prototype.matches = function (
+  this: HTMLDialogElement,
+  selector: string,
+): boolean {
+  if (selector === ":modal") return modalDialogs.has(this);
+  return originalMatches.call(this, selector);
+} as typeof HTMLDialogElement.prototype.matches;
+
+function mount(html = "<ogds-header></ogds-header>"): OgdsHeader {
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  const el = container.firstElementChild as OgdsHeader;
+  document.body.appendChild(el);
+  return el;
+}
+
+function mockMatchMedia(initialMatches: boolean) {
+  let matches = initialMatches;
+  const listeners = new Set<(event: { matches: boolean }) => void>();
+  const mql = {
+    get matches() {
+      return matches;
+    },
+    addEventListener: (
+      type: string,
+      cb: (event: { matches: boolean }) => void,
+    ) => {
+      if (type === "change") listeners.add(cb);
+    },
+    removeEventListener: (
+      type: string,
+      cb: (event: { matches: boolean }) => void,
+    ) => {
+      if (type === "change") listeners.delete(cb);
+    },
+  };
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => mql),
+  );
+  return {
+    setMatches(next: boolean) {
+      matches = next;
+      listeners.forEach((cb) => cb({ matches: next }));
+    },
+  };
+}
+
+function simulateSlotChange(
+  el: OgdsHeader,
+  slotName: string,
+  nodes: Node[],
+): HTMLElement {
+  const slot = el.shadowRoot!.querySelector<HTMLSlotElement>(
+    `slot[name="${slotName}"]`,
+  )!;
+  vi.spyOn(slot, "assignedNodes").mockReturnValue(nodes);
+  slot.dispatchEvent(new Event("slotchange", { bubbles: true }));
+  return slot.parentElement as HTMLElement;
+}
+
+beforeEach(() => {
+  mockMatchMedia(true);
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("default ARIA", () => {
+  it("sets role=banner when no role is present", async () => {
+    const el = mount();
+    await el.updateComplete;
+    expect(el.getAttribute("role")).toBe("banner");
+  });
+
+  it("does not override an author-supplied role", async () => {
+    const el = mount('<ogds-header role="region"></ogds-header>');
+    await el.updateComplete;
+    expect(el.getAttribute("role")).toBe("region");
+  });
+});
+
+describe("variant", () => {
+  it("defaults to extended and reflects as an attribute", async () => {
+    const el = mount();
+    await el.updateComplete;
+    expect(el.variant).toBe("extended");
+    expect(el.getAttribute("variant")).toBe("extended");
+  });
+
+  it("reflects an author-supplied variant", async () => {
+    const el = mount('<ogds-header variant="basic"></ogds-header>');
+    await el.updateComplete;
+    expect(el.variant).toBe("basic");
+    expect(el.getAttribute("variant")).toBe("basic");
+  });
+});
+
+describe("viewport sync", () => {
+  it("opens the nav non-modally at desktop widths", async () => {
+    mockMatchMedia(true);
+    const el = mount();
+    await el.updateComplete;
+    const dialog = el.shadowRoot!.querySelector("dialog")!;
+    expect(dialog.open).toBe(true);
+    expect(dialog.matches(":modal")).toBe(false);
+  });
+
+  it("leaves the nav closed below the desktop breakpoint", async () => {
+    mockMatchMedia(false);
+    const el = mount();
+    await el.updateComplete;
+    const dialog = el.shadowRoot!.querySelector("dialog")!;
+    expect(dialog.open).toBe(false);
+  });
+
+  it("closes a modally-open nav and reopens it non-modally when resizing to desktop", async () => {
+    const media = mockMatchMedia(false);
+    const el = mount();
+    await el.updateComplete;
+    const dialog = el.shadowRoot!.querySelector("dialog")!;
+    dialog.showModal();
+
+    media.setMatches(true);
+
+    expect(dialog.open).toBe(true);
+    expect(dialog.matches(":modal")).toBe(false);
+  });
+
+  it("closes a non-modally-open nav when resizing below desktop", async () => {
+    const media = mockMatchMedia(true);
+    const el = mount();
+    await el.updateComplete;
+    const dialog = el.shadowRoot!.querySelector("dialog")!;
+    expect(dialog.open).toBe(true);
+
+    media.setMatches(false);
+
+    expect(dialog.open).toBe(false);
+  });
+});
+
+describe("menu button", () => {
+  it("opens the nav modally and sets aria-expanded on click", async () => {
+    mockMatchMedia(false);
+    const el = mount();
+    await el.updateComplete;
+    const dialog = el.shadowRoot!.querySelector("dialog")!;
+    const menuBtn = el.shadowRoot!.querySelector(".menu-btn") as HTMLElement;
+
+    menuBtn.click();
+
+    expect(dialog.open).toBe(true);
+    expect(dialog.matches(":modal")).toBe(true);
+    expect(menuBtn.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("does not call showModal again while already open", async () => {
+    // dialog throws InvalidStateError from showModal() if
+    // the modal is already open
+    mockMatchMedia(false);
+    const el = mount();
+    await el.updateComplete;
+    const dialog = el.shadowRoot!.querySelector("dialog")!;
+    const menuBtn = el.shadowRoot!.querySelector(".menu-btn") as HTMLElement;
+    const showModalSpy = vi.spyOn(dialog, "showModal");
+
+    menuBtn.click();
+    menuBtn.click();
+
+    expect(showModalSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the nav via the close button", async () => {
+    mockMatchMedia(false);
+    const el = mount();
+    await el.updateComplete;
+    const dialog = el.shadowRoot!.querySelector("dialog")!;
+    const menuBtn = el.shadowRoot!.querySelector(".menu-btn") as HTMLElement;
+    menuBtn.click();
+
+    (el.shadowRoot!.querySelector(".nav-close") as HTMLElement).click();
+
+    expect(dialog.open).toBe(false);
+  });
+
+  it("resets aria-expanded when the nav is closed below desktop", async () => {
+    mockMatchMedia(false);
+    const el = mount();
+    await el.updateComplete;
+    const dialog = el.shadowRoot!.querySelector("dialog")!;
+    const menuBtn = el.shadowRoot!.querySelector(".menu-btn") as HTMLElement;
+    menuBtn.click();
+
+    dialog.close();
+
+    expect(menuBtn.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("does not reset aria-expanded from a desktop close", async () => {
+    mockMatchMedia(true);
+    const el = mount();
+    await el.updateComplete;
+    const dialog = el.shadowRoot!.querySelector("dialog")!;
+    const menuBtn = el.shadowRoot!.querySelector(".menu-btn") as HTMLElement;
+    menuBtn.setAttribute("aria-expanded", "true");
+
+    dialog.close();
+
+    expect(menuBtn.getAttribute("aria-expanded")).toBe("true");
+  });
+});
+
+describe("backdrop click", () => {
+  it("closes the nav when clicking the dialog backdrop", async () => {
+    mockMatchMedia(false);
+    const el = mount();
+    await el.updateComplete;
+    const dialog = el.shadowRoot!.querySelector("dialog")!;
+    dialog.showModal();
+
+    dialog.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(dialog.open).toBe(false);
+  });
+
+  it("does not close the nav when clicking content inside the dialog", async () => {
+    mockMatchMedia(false);
+    const el = mount();
+    await el.updateComplete;
+    const dialog = el.shadowRoot!.querySelector("dialog")!;
+    dialog.showModal();
+    const inner = el.shadowRoot!.querySelector(".nav-primary") as HTMLElement;
+
+    inner.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(dialog.open).toBe(true);
+  });
+});
+
+describe("optional slots", () => {
+  it("hides the info row until content is slotted", async () => {
+    const el = mount();
+    await el.updateComplete;
+    const wrapper = el.shadowRoot!.querySelector(".info") as HTMLElement;
+    expect(wrapper.hidden).toBe(true);
+
+    simulateSlotChange(el, "info", [document.createElement("div")]);
+    expect(wrapper.hidden).toBe(false);
+
+    simulateSlotChange(el, "info", []);
+    expect(wrapper.hidden).toBe(true);
+  });
+
+  it("hides the notifications row until content is slotted", async () => {
+    const el = mount();
+    await el.updateComplete;
+    const wrapper = el.shadowRoot!.querySelector(
+      ".notifications",
+    ) as HTMLElement;
+    expect(wrapper.hidden).toBe(true);
+
+    simulateSlotChange(el, "notifications", [document.createElement("div")]);
+    expect(wrapper.hidden).toBe(false);
+  });
+});

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -31,6 +31,8 @@ export type OgdsHeaderVariant = "basic" | "extended";
  * @cssprop --ogds-header-overlay-color - Color of the backdrop behind the open drawer.
  * @cssprop --ogds-header-divider-color - Color of hairline dividers/borders.
  * @cssprop --ogds-header-drawer-width - Width of the navigation drawer below the desktop breakpoint.
+ * @cssprop --ogds-header-icon-close-size - Height and width of the drawer's close icon.
+ * @cssprop --ogds-header-icon-menu-size - Height and width of the menu button's icon.
  * @cssprop --ogds-header-max-width - Max width of the header's content, centered with auto margins (like a USWDS grid container). Unset by default, so content spans the full width of the host.
  * @cssprop --ogds-header-padding-inline - Horizontal gutter applied alongside --ogds-header-max-width. Unset by default.
  * @cssprop --ogds-header-row-gap - Vertical gap between the rows of the header grid (logo/secondary nav, info, and primary nav).

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -1,7 +1,7 @@
 import { LitElement, css, html, unsafeCSS } from "lit";
 import { property } from "lit/decorators.js";
 
-import styles from "./ogds-header.css";
+import cssFileStyles from "./ogds-header.css";
 import iconMenu from "../../shared/icons/menu.svg";
 import iconClose from "../../shared/icons/close.svg";
 
@@ -9,6 +9,13 @@ import { adoptTokenStyles } from "../../core/token-styles";
 import { defineCustomElement } from "../../utils";
 
 const DESKTOP_QUERY = "(width >= 64rem)";
+
+const localStyles = css`
+  :host {
+    --ogds-header-icon-close: url("${unsafeCSS(iconClose)}");
+    --ogds-header-icon-menu: url("${unsafeCSS(iconMenu)}");
+  }
+`;
 
 export type OgdsHeaderVariant = "basic" | "extended";
 
@@ -49,15 +56,7 @@ export class OgdsHeader extends LitElement {
   /** @ignore */
   private _menuBtn: HTMLButtonElement | null = null;
 
-  static styles = [
-    css`
-      :host {
-        --ogds-header-icon-close: url("${unsafeCSS(iconClose)}");
-        --ogds-header-icon-menu: url("${unsafeCSS(iconMenu)}");
-      }
-    `,
-    styles,
-  ];
+  static styles = [localStyles, cssFileStyles];
 
   override connectedCallback() {
     super.connectedCallback();

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -112,6 +112,7 @@ export class OgdsHeader extends LitElement {
 
   /** @ignore */
   private _onMenuBtnClick() {
+    if (this._navDialog?.open) return;
     this._navDialog?.showModal();
     this._menuBtn?.setAttribute("aria-expanded", "true");
   }


### PR DESCRIPTION
# Summary

Added unit & end-to-end tests for the header component; fixed one small bug in the component while writing the tests

## Problem statement

The header component didn't have any tests, and while it's relatively simple, it still needs some tests to prove that it does what it's supposed to do and to prevent regressions.

## Solution

As noted in [this issue](https://github.com/jsdom/jsdom/issues/3294), jsdom doesn't implement `<dialog>` so these tests polyfill enough of that element in jsdom to keep the tests from crashing. But without a real element to test against in the unit tests, adding some basic e2e smoke tests in playwright to run in real browsers is worth the overhead & CI time of more e2e tests.

## Testing and review

Are there gaps in the test coverage?