### PR TITLE
Improve Storybook functionality

### DIFF
--- a/src/components/ogds-accordion-toggle/docs.mdx
+++ b/src/components/ogds-accordion-toggle/docs.mdx
@@ -1,4 +1,10 @@
-import { Meta, Title, Primary, Stories } from "@storybook/addon-docs/blocks";
+import {
+  Meta,
+  Title,
+  Primary,
+  Controls,
+  Stories,
+} from "@storybook/addon-docs/blocks";
 
 <Meta isTemplate />
 
@@ -11,6 +17,14 @@ The accordion toggle provides a single button to expand or collapse all panels i
 ## Default
 
 <Primary />
+
+---
+
+## Inputs
+
+The component accepts the following inputs (props, slots, and CSS custom properties).
+
+<Controls />
 
 ---
 

--- a/src/components/ogds-accordion-toggle/index.ts
+++ b/src/components/ogds-accordion-toggle/index.ts
@@ -13,7 +13,7 @@ import styles from "./ogds-accordion-toggle.css";
  * @slot expand-label - **Plain text.** Button label when all panels are collapsed. Defaults to "Expand All".
  * @slot collapse-label - **Plain text.** Button label when one or more panels are open. Defaults to "Collapse All".
  *
- * @csspart button - The toggle button.
+ * @csspart button - The toggle button itself. This being a [CSS shadow part](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Shadow_parts) will let you style it however you need to with normal CSS.
  *
  * @element ogds-accordion-toggle
  */

--- a/src/components/ogds-accordion-toggle/index.ts
+++ b/src/components/ogds-accordion-toggle/index.ts
@@ -10,8 +10,8 @@ import styles from "./ogds-accordion-toggle.css";
  *
  * @attribute {string} controls - The `id` of the `<ogds-accordion>` to control. Required.
  *
- * @slot expand-label - Button label when all panels are collapsed. Defaults to "Expand All".
- * @slot collapse-label - Button label when one or more panels are open. Defaults to "Collapse All".
+ * @slot expand-label - **Plain text.** Button label when all panels are collapsed. Defaults to "Expand All".
+ * @slot collapse-label - **Plain text.** Button label when one or more panels are open. Defaults to "Collapse All".
  *
  * @csspart button - The toggle button.
  *

--- a/src/components/ogds-accordion-toggle/ogds-accordion-toggle.stories.ts
+++ b/src/components/ogds-accordion-toggle/ogds-accordion-toggle.stories.ts
@@ -1,11 +1,18 @@
-import { html } from "lit";
+import { html, nothing } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import "./index";
 import "../ogds-accordion/index";
 import ComponentDocs from "./docs.mdx";
 import { expect, userEvent, waitFor } from "storybook/test";
 import { within } from "shadow-dom-testing-library";
+import { getStorybookHelpers } from "@wc-toolkit/storybook-helpers";
+import type { Args } from "storybook/internal/csf";
 
-const items = html`
+const { args, argTypes } = getStorybookHelpers("ogds-accordion-toggle", {
+  excludeCategories: ["methods"],
+});
+
+const items = `
   <details>
     <summary>First Amendment</summary>
     <p>
@@ -32,34 +39,49 @@ const items = html`
   </details>
 `;
 
+const renderToggle = (args: Args) => html`
+  <ogds-accordion-toggle controls=${args.controls}>
+    ${
+      args["expand-label-slot"]
+        ? html`<span slot="expand-label">${args["expand-label-slot"]}</span>`
+        : nothing
+    }
+    ${
+      args["collapse-label-slot"]
+        ? html`<span slot="collapse-label"
+            >${args["collapse-label-slot"]}</span
+          >`
+        : nothing
+    }
+  </ogds-accordion-toggle>
+  <ogds-accordion id=${args.controls}>${unsafeHTML(items)}</ogds-accordion>
+`;
+
 export default {
   title: "Components/Accordion Toggle",
   component: "ogds-accordion-toggle",
   tags: ["alpha"],
+  args: {
+    ...args,
+    controls: "accordion-toggle-default",
+  },
+  argTypes,
   parameters: {
     docs: {
       page: ComponentDocs,
     },
   },
+  render: (args: Args) => renderToggle(args),
 };
 
-export const Default = {
-  render: () => html`
-    <ogds-accordion-toggle
-      controls="accordion-toggle-default"
-    ></ogds-accordion-toggle>
-    <ogds-accordion id="accordion-toggle-default">${items}</ogds-accordion>
-  `,
-};
+export const Default = {};
 
 export const CustomLabels = {
-  render: () => html`
-    <ogds-accordion-toggle controls="accordion-toggle-custom">
-      <span slot="expand-label">Show All</span>
-      <span slot="collapse-label">Hide All</span>
-    </ogds-accordion-toggle>
-    <ogds-accordion id="accordion-toggle-custom">${items}</ogds-accordion>
-  `,
+  args: {
+    controls: "accordion-toggle-custom",
+    "expand-label-slot": "Show All",
+    "collapse-label-slot": "Hide All",
+  },
 };
 
 export const ToggleTest = {
@@ -68,12 +90,9 @@ export const ToggleTest = {
       disable: true,
     },
   },
-  render: () => html`
-    <ogds-accordion-toggle
-      controls="accordion-toggle-test"
-    ></ogds-accordion-toggle>
-    <ogds-accordion id="accordion-toggle-test">${items}</ogds-accordion>
-  `,
+  args: {
+    controls: "accordion-toggle-test",
+  },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByShadowRole("button");

--- a/src/components/ogds-accordion/docs.mdx
+++ b/src/components/ogds-accordion/docs.mdx
@@ -1,4 +1,10 @@
-import { Meta, Title, Primary, Stories } from "@storybook/addon-docs/blocks";
+import {
+  Meta,
+  Title,
+  Primary,
+  Controls,
+  Stories,
+} from "@storybook/addon-docs/blocks";
 
 <Meta isTemplate />
 
@@ -17,6 +23,14 @@ Accordions show and hide sections of related content on a page. This component c
 ## Example Accordion
 
 <Primary />
+
+## Inputs
+
+The component accepts the following inputs (props, slots, and CSS custom properties).
+
+<Controls />
+
+---
 
 ## Guidance
 

--- a/src/components/ogds-accordion/index.ts
+++ b/src/components/ogds-accordion/index.ts
@@ -26,7 +26,7 @@ import { property } from "lit/decorators.js";
  * @attribute {boolean} use-list-semantics - Adds `role="list"` to the component and `role="listitem"` to each `<details>` child, conveying the accordion as a list to assistive technologies. Mutually exclusive with `heading-level`.
  * @attribute {number} heading-level - Sets a heading level for each accordion panel by adding `role="heading"` and the corresponding `aria-level` to each `<summary>` element. Has no effect when set to `0` (the default). Mutually exclusive with `use-list-semantics`.
  *
- * @slot - The default (only) slot for the `<ogds-accordion>` expects one or more plain HTML `<details>` elements.
+ * @slot - **HTML markup.** The default (only) slot for the `<ogds-accordion>` expects one or more plain HTML `<details>` elements.
  * @element ogds-accordion
  */
 export class OgdsAccordion extends LitElement {

--- a/src/components/ogds-accordion/index.ts
+++ b/src/components/ogds-accordion/index.ts
@@ -39,8 +39,9 @@ export class OgdsAccordion extends LitElement {
   @property({ type: Number, attribute: "heading-level" })
   headingLevel = 0;
 
-  declare detailsChildren: HTMLCollectionOf<HTMLDetailsElement> | undefined;
-  declare childRoles: Map<HTMLDetailsElement, Set<string>>;
+  declare private detailsChildren:
+    HTMLCollectionOf<HTMLDetailsElement> | undefined;
+  declare private childRoles: Map<HTMLDetailsElement, Set<string>>;
 
   override createRenderRoot() {
     return this;
@@ -84,7 +85,7 @@ export class OgdsAccordion extends LitElement {
     this.applyChildRoles();
   }
 
-  getDetailsChildren() {
+  private getDetailsChildren() {
     const detailsEls = this.getElementsByTagName("details");
     if (detailsEls.length > 0) {
       return detailsEls;
@@ -95,7 +96,7 @@ export class OgdsAccordion extends LitElement {
     }
   }
 
-  addListSemantics() {
+  private addListSemantics() {
     if (this.useListSemantics && this.detailsChildren) {
       Array.from(this.detailsChildren).forEach((el) =>
         this.childRoles.get(el)?.add("listitem"),
@@ -104,7 +105,7 @@ export class OgdsAccordion extends LitElement {
     }
   }
 
-  addHeadingSemantics() {
+  private addHeadingSemantics() {
     const headingLevel = this.headingLevel;
 
     if (headingLevel !== 0 && this.detailsChildren) {
@@ -118,7 +119,7 @@ export class OgdsAccordion extends LitElement {
     }
   }
 
-  applyChildRoles() {
+  private applyChildRoles() {
     this.childRoles.forEach((roles, el) => {
       if (roles.size > 0) el.setAttribute("role", Array.from(roles).join(" "));
     });

--- a/src/components/ogds-accordion/index.ts
+++ b/src/components/ogds-accordion/index.ts
@@ -26,7 +26,7 @@ import { property } from "lit/decorators.js";
  * @attribute {boolean} use-list-semantics - Adds `role="list"` to the component and `role="listitem"` to each `<details>` child, conveying the accordion as a list to assistive technologies. Mutually exclusive with `heading-level`.
  * @attribute {number} heading-level - Sets a heading level for each accordion panel by adding `role="heading"` and the corresponding `aria-level` to each `<summary>` element. Has no effect when set to `0` (the default). Mutually exclusive with `use-list-semantics`.
  *
- * @slot - The default (only) slot for the <ogds-accordion> expects one or more plain HTML <details> elements.
+ * @slot - The default (only) slot for the `<ogds-accordion>` expects one or more plain HTML `<details>` elements.
  * @element ogds-accordion
  */
 export class OgdsAccordion extends LitElement {

--- a/src/components/ogds-accordion/ogds-accordion.spec.ts
+++ b/src/components/ogds-accordion/ogds-accordion.spec.ts
@@ -35,7 +35,7 @@ describe("getDetailsChildren", () => {
     `);
     await el.updateComplete;
     const detailsChildren = (
-      el as unknown as {
+      el as any as {
         detailsChildren?: HTMLCollectionOf<HTMLDetailsElement>;
       }
     ).detailsChildren;

--- a/src/components/ogds-accordion/ogds-accordion.spec.ts
+++ b/src/components/ogds-accordion/ogds-accordion.spec.ts
@@ -34,8 +34,13 @@ describe("getDetailsChildren", () => {
       </ogds-accordion>
     `);
     await el.updateComplete;
-    expect(el.detailsChildren).toBeDefined();
-    expect(el.detailsChildren?.length).toBe(2);
+    const detailsChildren = (
+      el as unknown as {
+        detailsChildren?: HTMLCollectionOf<HTMLDetailsElement>;
+      }
+    ).detailsChildren;
+    expect(detailsChildren).toBeDefined();
+    expect(detailsChildren?.length).toBe(2);
   });
 
   it("logs a console error when no details children are present", async () => {

--- a/src/components/ogds-accordion/ogds-accordion.stories.ts
+++ b/src/components/ogds-accordion/ogds-accordion.stories.ts
@@ -1,8 +1,15 @@
 import { html } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import "./index";
 import ComponentDocs from "./docs.mdx";
+import { getStorybookHelpers } from "@wc-toolkit/storybook-helpers";
+import type { Args } from "storybook/internal/csf";
 
-const items = html`
+const { args, argTypes, template } = getStorybookHelpers("ogds-accordion", {
+  excludeCategories: ["methods"],
+});
+
+const items = `
   <details>
     <summary>First Amendment</summary>
     <p>
@@ -33,57 +40,54 @@ export default {
   title: "Components/Accordion",
   component: "ogds-accordion",
   tags: ["alpha"],
+  args: {
+    ...args,
+    "default-slot": items,
+  },
+  argTypes,
   parameters: {
     docs: {
       page: ComponentDocs,
     },
   },
+  render: (args: Args) => template(args),
 };
 
-export const Default = {
-  render: () => html`<ogds-accordion>${items}</ogds-accordion>`,
-};
+export const Default = {};
 
 export const Bordered = {
-  render: () =>
-    html`<ogds-accordion class="bordered">${items}</ogds-accordion>`,
+  args: { class: "bordered" },
 };
 
 export const WithChevronIcons = {
-  render: () =>
-    html`<ogds-accordion class="with-icon">${items}</ogds-accordion>`,
+  args: { class: "with-icon" },
 };
 
 export const WithChevronIconsRight = {
-  render: () =>
-    html`<ogds-accordion class="with-icon right">${items}</ogds-accordion>`,
+  args: { class: "with-icon right" },
 };
 
 export const WithChevronIconsBordered = {
-  render: () =>
-    html`<ogds-accordion class="with-icon bordered">${items}</ogds-accordion>`,
+  args: { class: "with-icon bordered" },
 };
 
 export const WithPlusIcons = {
-  render: () =>
-    html`<ogds-accordion class="with-icon plus">${items}</ogds-accordion>`,
+  args: { class: "with-icon plus" },
 };
 
 export const WithPlusIconsBordered = {
-  render: () =>
-    html`<ogds-accordion class="with-icon plus bordered"
-      >${items}</ogds-accordion
-    >`,
+  args: { class: "with-icon plus bordered" },
 };
 
 export const WithPlusIconsRight = {
-  render: () =>
-    html`<ogds-accordion class="with-icon plus right"
-      >${items}</ogds-accordion
-    >`,
+  args: { class: "with-icon plus right" },
 };
 
 export const WithPlusIconsRightWithoutCustomElement = {
+  // This variant intentionally doesn't render the custom element, so it
+  // isn't driven by the shared `<ogds-accordion>` args/template.
   render: () =>
-    html`<div class="ogds-accordion with-icon plus right">${items}</div>`,
+    html`<div class="ogds-accordion with-icon plus right">
+      ${unsafeHTML(items)}
+    </div>`,
 };

--- a/src/components/ogds-alert/index.ts
+++ b/src/components/ogds-alert/index.ts
@@ -14,8 +14,8 @@ import styles from "./ogds-alert.css";
  * @attribute {string} type - The type of alert (info, warning, etc)
  * @attribute {string} noIcon - Use this attribute to hide the icon
  *
- * @slot heading - Text for the heading. Make sure to specify the correct heading level (h2, h3, etc)
- * @slot body - Body content for the alert. Can contain HTML (links, etc).
+ * @slot heading - **HTML markup.** Text for the heading. Make sure to specify the correct heading level (h2, h3, etc)
+ * @slot body - **HTML markup.** Body content for the alert. Can contain HTML (links, etc).
  *
  * @tagname ogds-alert
  */

--- a/src/components/ogds-alert/ogds-alert.css
+++ b/src/components/ogds-alert/ogds-alert.css
@@ -17,12 +17,12 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    margin-left: var(--ogds-spacing-4);
     padding-block: var(--theme-alert-padding-y, var(--ogds-spacing-2));
     padding-inline: var(--theme-alert-padding-x, var(--ogds-spacing-3));
+    position: relative;
 
     .ogds-alert__icon {
-      left: 2rem;
+      left: var(--theme-alert-padding-x, var(--ogds-spacing-3));
       position: absolute;
       width: 2rem; /* TODO */
     }
@@ -30,10 +30,12 @@
     .ogds-alert__heading {
       align-items: center;
       display: flex;
+      margin-left: 2.5rem;
     }
 
     .ogds-alert__text {
       margin-bottom: 0;
+      margin-left: 2.5rem;
       margin-top: 0;
     }
   }
@@ -77,20 +79,26 @@
 
 .ogds-alert--slim {
   .ogds-alert__body {
-    margin-left: 1rem;
-
     .ogds-alert__icon {
       width: 1.5rem;
+    }
+
+    .ogds-alert__heading,
+    .ogds-alert__text {
+      margin-left: 2rem;
     }
   }
 }
 
 .ogds-alert--no-icon {
   .ogds-alert__body {
-    margin-left: 0;
-
     .ogds-alert__icon {
       display: none;
+    }
+
+    .ogds-alert__heading,
+    .ogds-alert__text {
+      margin-left: 0;
     }
   }
 }

--- a/src/components/ogds-banner/index.ts
+++ b/src/components/ogds-banner/index.ts
@@ -104,12 +104,12 @@ const OGDS_BANNER_TRANSLATIONS: Record<
  * @cssprop --ogds-banner-link-hover-color - Sets the default link color.
  * @cssprop --ogds-banner-text-color - Sets the default text color.
  *
- * @slot banner-text - The text for official government website text.
- * @slot banner-action - Action text label "Here's how you know."
- * @slot domain-heading - Heading text for the domain section.
- * @slot domain-text - Body text for domain section.
- * @slot https-heading - Heading for HTTPs section.
- * @slot https-text - Body text for HTTPs section.
+ * @slot banner-text - **Plain text.** The text for official government website text.
+ * @slot banner-action - **Plain text.** Action text label "Here's how you know."
+ * @slot domain-heading - **Plain text.** Heading text for the domain section.
+ * @slot domain-text - **Plain text.** Body text for domain section.
+ * @slot https-heading - **Plain text.** Heading for HTTPs section.
+ * @slot https-text - **Plain text.** Body text for HTTPs section.
  *
  * @element ogds-banner
  */

--- a/src/components/ogds-header/docs.mdx
+++ b/src/components/ogds-header/docs.mdx
@@ -1,4 +1,10 @@
-import { Meta, Title, Primary, Stories } from "@storybook/addon-docs/blocks";
+import {
+  Meta,
+  Title,
+  Primary,
+  Controls,
+  Stories,
+} from "@storybook/addon-docs/blocks";
 
 <Meta isTemplate />
 
@@ -9,6 +15,14 @@ Based on the [USWDS Header component](https://designsystem.digital.gov/component
 ## Example
 
 <Primary />
+
+## Inputs
+
+The component accepts the following inputs (props, slots, and CSS custom properties).
+
+<Controls />
+
+---
 
 ## Author markup
 

--- a/src/components/ogds-header/ogds-header.stories.ts
+++ b/src/components/ogds-header/ogds-header.stories.ts
@@ -160,7 +160,7 @@ const secondaryLinksHTML = `
 export default {
   title: "Components/Header",
   component: "ogds-header",
-  tags: ["experimental"],
+  tags: ["alpha"],
   args: {
     ...args,
     variant: "extended",

--- a/src/components/ogds-header/ogds-header.stories.ts
+++ b/src/components/ogds-header/ogds-header.stories.ts
@@ -3,6 +3,12 @@ import "./index";
 import "../ogds-primary-nav";
 import "../ogds-accordion";
 import ComponentDocs from "./docs.mdx";
+import { getStorybookHelpers } from "@wc-toolkit/storybook-helpers";
+import type { Args } from "storybook/internal/csf";
+
+const { args, argTypes, template } = getStorybookHelpers("ogds-header", {
+  excludeCategories: ["methods"],
+});
 
 const searchStyles = html`
   <style>
@@ -104,45 +110,90 @@ const genericSearch = html`
   </form>
 `;
 
+// This has to be a string for the args-driven
+// stories below (Extended/Basic), since `template()` needs slot content as
+// HTML strings rather than lit TemplateResults. Hence no `html` tag
+const genericPrimaryNavHTML = `
+  <ogds-primary-nav>
+    <ul>
+      <li><a href="#" aria-current="page">Current section</a></li>
+      <li>
+        <details>
+          <summary>Benefits</summary>
+          <ul>
+            <li><a href="#">Navigation link</a></li>
+            <li><a href="#">Navigation link</a></li>
+            <li><a href="#">Navigation link</a></li>
+            <li><a href="#">Navigation link</a></li>
+          </ul>
+        </details>
+      </li>
+      <li>
+        <details>
+          <summary>Resources</summary>
+          <ul>
+            <li><a href="#">Navigation link</a></li>
+            <li><a href="#">Navigation link</a></li>
+            <li><a href="#">Navigation link</a></li>
+          </ul>
+        </details>
+      </li>
+      <li><a href="#">Simple link</a></li>
+    </ul>
+  </ogds-primary-nav>
+`;
+
+const genericSearchHTML = `
+  <form class="example-search" role="search">
+    <input type="search" aria-label="Search" name="q" />
+    <button type="submit">Search</button>
+  </form>
+`;
+
+const secondaryLinksHTML = `
+  <ul class="example-secondary-links">
+    <li><a href="#">Secondary link</a></li>
+    <li><a href="#">Another secondary link</a></li>
+  </ul>
+`;
+
 export default {
   title: "Components/Header",
   component: "ogds-header",
   tags: ["experimental"],
+  args: {
+    ...args,
+    variant: "extended",
+    "logo-slot": `<div><a href="/">Project name</a></div>`,
+    "notifications-slot": `<div>Notifications</div>`,
+    "nav-secondary-slot": secondaryLinksHTML + genericSearchHTML,
+    "nav-primary-slot": genericPrimaryNavHTML,
+  },
+  argTypes,
   parameters: {
     docs: {
       page: ComponentDocs,
     },
   },
+  render: (args: Args) =>
+    html`${searchStyles} ${secondaryLinksStyles} ${template(args)}`,
 };
 
-export const Extended = {
-  render: () => html`
-    ${searchStyles} ${secondaryLinksStyles}
-    <ogds-header variant="extended">
-      <div slot="logo"><a href="/">Project name</a></div>
-      <div slot="notifications">Notifications</div>
-      <ul class="example-secondary-links" slot="nav-secondary">
-        <li><a href="#">Secondary link</a></li>
-        <li><a href="#">Another secondary link</a></li>
-      </ul>
-      ${genericSearch} ${genericPrimaryNav}
-    </ogds-header>
-  `,
-};
+export const Extended = {};
 
 export const Basic = {
-  render: () => html`
-    ${searchStyles}
-    <ogds-header variant="basic">
-      <div slot="logo"><a href="/">Project name</a></div>
-      ${genericSearch} ${genericPrimaryNav}
-    </ogds-header>
-  `,
+  args: {
+    variant: "basic",
+    "notifications-slot": "",
+    "nav-secondary-slot": genericSearchHTML,
+  },
 };
 
+// The following stories kind of need to be hand-authored markup
+// since they're showing a full layout
 export const EmpXExample = {
   name: "State agency header with info section",
-  render: () => html`
+  render: (args: Args) => html`
     <style>
       .state-with-info-example {
         --ogds-header-nav-primary-row-background-color: #fff;
@@ -164,7 +215,7 @@ export const EmpXExample = {
         }
       }
     </style>
-    <ogds-header variant="extended" class="state-with-info-example">
+    <ogds-header variant=${args.variant} class="state-with-info-example">
       <a slot="logo" href="/">
         <img
           src="https://paidleave.maryland.gov/img/OsA2lxQa9u-400.webp"
@@ -208,7 +259,8 @@ export const MarylandFAMLIExample = {
       },
     },
   },
-  render: () => html`
+  // Like the empx example, needs to be a full hand-authored layout
+  render: (args: Args) => html`
     <style>
       .famli-register-button {
         border-radius: var(--ogds-theme-button-border-radius);
@@ -303,7 +355,7 @@ export const MarylandFAMLIExample = {
       }
     </style>
 
-    <ogds-header variant="extended" class="logged-out-example">
+    <ogds-header variant=${args.variant} class="logged-out-example">
       <a slot="logo" href="/">
         <img
           src="https://paidleave.maryland.gov/img/OsA2lxQa9u-400.webp"
@@ -392,7 +444,8 @@ export const WorkerXExample = {
       },
     },
   },
-  render: () => html`
+  // Hand-authored markup for layout as above
+  render: (args: Args) => html`
     ${searchStyles}
     <style>
       .example-workerx-header {
@@ -421,7 +474,7 @@ export const WorkerXExample = {
       }
     </style>
 
-    <ogds-header class="example-workerx-header" variant="extended">
+    <ogds-header class="example-workerx-header" variant=${args.variant}>
       <a slot="logo" href="/">
         <img
           src="https://paidleave.maryland.gov/img/OsA2lxQa9u-400.webp"

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -20,11 +20,11 @@ const localStyles = css`
 /**
  * @summary A responsive site header, styled to match the USWDS basic and extended header patterns.
  *
- * @slot logo - The site logo/wordmark, typically a link to the homepage.
- * @slot info - Optional. A banner/alert row shown between the navbar and the navigation drawer.
- * @slot nav-primary - Expects an `<ogds-primary-nav>` with the site's primary section links, or some other primary nav implementation.
- * @slot notifications - Optional. Content like an account or notifications indicator shown alongside the primary nav.
- * @slot nav-secondary - Optional. Secondary links and/or a search form. At desktop widths (extended variant), shown aligned with the logo; below the desktop breakpoint it folds into the drawer with the primary nav.
+ * @slot logo - **HTML markup.** The site logo/wordmark, typically a link to the homepage.
+ * @slot info - **HTML markup.** Optional. A banner/alert row shown between the navbar and the navigation drawer.
+ * @slot nav-primary - **HTML markup.** Expects an `<ogds-primary-nav>` with the site's primary section links, or some other primary nav implementation.
+ * @slot notifications - **HTML markup.** Optional. Content like an account or notifications indicator shown alongside the primary nav.
+ * @slot nav-secondary - **HTML markup.** Optional. Secondary links and/or a search form. At desktop widths (extended variant), shown aligned with the logo; below the desktop breakpoint it folds into the drawer with the primary nav.
  *
  * @cssprop --ogds-header-navbar-background-color - Background color of the navbar row (logo + menu button). Transparent by default.
  * @cssprop --ogds-header-info-background-color - Background color of the info row. Transparent by default.

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -17,8 +17,6 @@ const localStyles = css`
   }
 `;
 
-export type OgdsHeaderVariant = "basic" | "extended";
-
 /**
  * @summary A responsive site header, styled to match the USWDS basic and extended header patterns.
  *
@@ -47,7 +45,7 @@ export type OgdsHeaderVariant = "basic" | "extended";
  * @element ogds-header
  */
 export class OgdsHeader extends LitElement {
-  @property({ reflect: true }) variant: OgdsHeaderVariant = "extended";
+  @property({ reflect: true }) variant: "basic" | "extended" = "extended";
 
   /** @ignore */
   private _desktopQuery: MediaQueryList | null = null;
@@ -197,5 +195,7 @@ export class OgdsHeader extends LitElement {
     `;
   }
 }
+
+export type OgdsHeaderVariant = OgdsHeader["variant"];
 
 defineCustomElement("ogds-header", OgdsHeader);

--- a/src/components/ogds-primary-nav/docs.mdx
+++ b/src/components/ogds-primary-nav/docs.mdx
@@ -1,4 +1,10 @@
-import { Meta, Title, Primary, Stories } from "@storybook/addon-docs/blocks";
+import {
+  Meta,
+  Title,
+  Primary,
+  Controls,
+  Stories,
+} from "@storybook/addon-docs/blocks";
 
 <Meta isTemplate />
 
@@ -11,6 +17,14 @@ The primary nav lists the main sections of a site. On narrow viewports its subme
 ## Example Primary Nav
 
 <Primary />
+
+## Inputs
+
+The component accepts the following inputs (props, slots, and CSS custom properties).
+
+<Controls />
+
+---
 
 ## Author markup
 

--- a/src/components/ogds-primary-nav/index.ts
+++ b/src/components/ogds-primary-nav/index.ts
@@ -40,7 +40,7 @@ let instanceCount = 0;
  * @cssprop --ogds-primary-nav-submenu-background-color - Background color of a submenu panel, and of its open toggle at the desktop breakpoint.
  * @cssprop --ogds-primary-nav-submenu-link-color - Text color for links inside a submenu.
  *
- * @slot - Expects a single `<ul>` of `<li>` items, each containing either an `<a>` or a `<details>` submenu.
+ * @slot - **HTML markup.** Expects a single `<ul>` of `<li>` items, each containing either an `<a>` or a `<details>` submenu.
  * @element ogds-primary-nav
  */
 export class OgdsPrimaryNav extends LitElement {

--- a/src/components/ogds-primary-nav/ogds-primary-nav.stories.ts
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.stories.ts
@@ -39,7 +39,7 @@ const items = `
 export default {
   title: "Components/Primary Nav",
   component: "ogds-primary-nav",
-  tags: ["experimental"],
+  tags: ["alpha"],
   args: {
     ...args,
     "default-slot": items,

--- a/src/components/ogds-primary-nav/ogds-primary-nav.stories.ts
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.stories.ts
@@ -1,8 +1,15 @@
 import { html } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import "./index";
 import ComponentDocs from "./docs.mdx";
+import { getStorybookHelpers } from "@wc-toolkit/storybook-helpers";
+import type { Args } from "storybook/internal/csf";
 
-const items = html`
+const { args, argTypes, template } = getStorybookHelpers("ogds-primary-nav", {
+  excludeCategories: ["methods"],
+});
+
+const items = `
   <ul>
     <li><a href="#" aria-current="page">Current section</a></li>
     <li>
@@ -33,16 +40,20 @@ export default {
   title: "Components/Primary Nav",
   component: "ogds-primary-nav",
   tags: ["experimental"],
+  args: {
+    ...args,
+    "default-slot": items,
+  },
+  argTypes,
   parameters: {
     docs: {
       page: ComponentDocs,
     },
   },
+  render: (args: Args) => template(args),
 };
 
-export const Default = {
-  render: () => html`<ogds-primary-nav>${items}</ogds-primary-nav>`,
-};
+export const Default = {};
 
 export const WithoutCustomElement = {
   render: () =>
@@ -51,7 +62,7 @@ export const WithoutCustomElement = {
       role="navigation"
       aria-label="Primary navigation"
     >
-      ${items}
+      ${unsafeHTML(items)}
     </div>`,
 };
 
@@ -67,5 +78,4 @@ export const Mobile = {
       },
     },
   },
-  render: () => html`<ogds-primary-nav>${items}</ogds-primary-nav>`,
 };

--- a/src/components/ogds-task-list/docs.mdx
+++ b/src/components/ogds-task-list/docs.mdx
@@ -1,4 +1,10 @@
-import { Meta, Title, Primary, Stories } from "@storybook/addon-docs/blocks";
+import {
+  Meta,
+  Title,
+  Primary,
+  Controls,
+  Stories,
+} from "@storybook/addon-docs/blocks";
 
 <Meta isTemplate />
 
@@ -10,7 +16,19 @@ A Task Progress List guides users through a complex workflow by breaking it down
 
 <Primary />
 
+## Inputs
+
+The component accepts the following inputs (props, slots, and CSS custom properties).
+
+<Controls />
+
+---
+
 ## Guidance
+
+The Task List is used primarily for lengthy or complex workflows (non-sequential), e.g. registration, rather than simple, short steps.
+
+Each task is rendered with an `<ogds-task-list-step>` element — see its [own documentation](?path=/docs/components-tasklist-taskliststep--docs) for the full list of attributes and slots available on individual steps, including the status badge label slot.
 
 ### When to use the component
 

--- a/src/components/ogds-task-list/docs.mdx
+++ b/src/components/ogds-task-list/docs.mdx
@@ -28,7 +28,7 @@ The component accepts the following inputs (props, slots, and CSS custom propert
 
 The Task List is used primarily for lengthy or complex workflows (non-sequential), e.g. registration, rather than simple, short steps.
 
-Each task is rendered with an `<ogds-task-list-step>` element — see its [own documentation](?path=/docs/components-tasklist-taskliststep--docs) for the full list of attributes and slots available on individual steps, including the status badge label slot.
+Each task is rendered with an `<ogds-task-list-step>` element — see its [own documentation](?path=/docs/components-task-list-taskliststep--docs) for the full list of attributes and slots available on individual steps, including the status badge label slot.
 
 ### When to use the component
 

--- a/src/components/ogds-task-list/ogds-task-list-step.docs.mdx
+++ b/src/components/ogds-task-list/ogds-task-list-step.docs.mdx
@@ -1,0 +1,37 @@
+import {
+  Meta,
+  Title,
+  Primary,
+  Controls,
+  Stories,
+} from "@storybook/addon-docs/blocks";
+
+<Meta isTemplate />
+
+<Title />
+
+A single step within an `<ogds-task-list>`. Each `<ogds-task-list-step>` is rendered as a list item with a title, a status badge, and optional supporting content.
+
+---
+
+## Default
+
+<Primary />
+
+---
+
+## Inputs
+
+The component accepts the following inputs (props, slots, and CSS custom properties).
+
+<Controls />
+
+---
+
+## Variations
+
+<Stories />
+
+## Guidance
+
+`<ogds-task-list-step>` elements are meant to be used as children of an [`<ogds-task-list>`](?path=/docs/components-tasklist--docs), which counts completed steps and renders them in an accessible list. The stories on this page render steps outside of that context to preview each variation in isolation.

--- a/src/components/ogds-task-list/ogds-task-list-step.docs.mdx
+++ b/src/components/ogds-task-list/ogds-task-list-step.docs.mdx
@@ -34,4 +34,4 @@ The component accepts the following inputs (props, slots, and CSS custom propert
 
 ## Guidance
 
-`<ogds-task-list-step>` elements are meant to be used as children of an [`<ogds-task-list>`](?path=/docs/components-tasklist--docs), which counts completed steps and renders them in an accessible list. The stories on this page render steps outside of that context to preview each variation in isolation.
+`<ogds-task-list-step>` elements are meant to be used as children of an [`<ogds-task-list>`](?path=/docs/components-task-list--docs), which counts completed steps and renders them in an accessible list. The stories on this page render steps outside of that context to preview each variation in isolation.

--- a/src/components/ogds-task-list/ogds-task-list-step.stories.ts
+++ b/src/components/ogds-task-list/ogds-task-list-step.stories.ts
@@ -12,9 +12,9 @@ const { args, argTypes, template } = getStorybookHelpers(
 );
 
 export default {
-  title: "Components/TaskList/TaskListStep",
+  title: "Components/Task List/Task List Step",
   component: "ogds-task-list-step",
-  tags: ["experimental"],
+  tags: ["alpha"],
   args: {
     ...args,
     status: "in-progress",

--- a/src/components/ogds-task-list/ogds-task-list-step.stories.ts
+++ b/src/components/ogds-task-list/ogds-task-list-step.stories.ts
@@ -1,0 +1,80 @@
+import "./ogds-task-list-step";
+import "../ogds-alert/index";
+import ComponentDocs from "./ogds-task-list-step.docs.mdx";
+import { getStorybookHelpers } from "@wc-toolkit/storybook-helpers";
+import type { Args } from "storybook/internal/csf";
+
+const { args, argTypes, template } = getStorybookHelpers(
+  "ogds-task-list-step",
+  {
+    excludeCategories: ["methods"],
+  },
+);
+
+export default {
+  title: "Components/TaskList/TaskListStep",
+  component: "ogds-task-list-step",
+  tags: ["experimental"],
+  args: {
+    ...args,
+    status: "in-progress",
+    url: "/some-task",
+    "title-slot": "Tell us about your employer",
+    "description-slot":
+      "We need a few details to verify your business registration.",
+  },
+  argTypes,
+  parameters: {
+    docs: {
+      page: ComponentDocs,
+    },
+    a11y: {
+      config: {
+        rules: [
+          // aria-required-parent fires because role="listitem" requires a parent
+          // list, but these stories render the step in isolation for design preview.
+          { id: "aria-required-parent", enabled: false },
+        ],
+      },
+    },
+  },
+  render: (args: Args) => template(args),
+};
+
+export const Default = {};
+
+export const CustomStatusLabel = {
+  args: {
+    "status-label-slot": "Started",
+  },
+};
+
+export const WithAlert = {
+  args: {
+    "alert-slot": `<ogds-alert type="warning"><p slot="body">We need more information before this task can be completed.</p></ogds-alert>`,
+  },
+};
+
+export const WithSavedData = {
+  args: {
+    status: "completed",
+    "description-slot": "",
+    "saved-data-slot": `<dl><dt>Phone number</dt><dd>(410) 123-4567</dd></dl>`,
+  },
+};
+
+export const Blocked = {
+  args: {
+    status: "cannot-start-yet",
+    url: "",
+    "title-slot": "Submit your Maryland Resident Agent details",
+    "description-slot": "",
+  },
+};
+
+export const CustomBlockedMessage = {
+  args: {
+    ...Blocked.args,
+    "blocked-message-slot": 'Complete "Tell us about your employer" first.',
+  },
+};

--- a/src/components/ogds-task-list/ogds-task-list-step.ts
+++ b/src/components/ogds-task-list/ogds-task-list-step.ts
@@ -6,9 +6,6 @@ import styles from "./ogds-task-list-step.css";
 import { adoptTokenStyles } from "../../core/token-styles";
 import { defineCustomElement } from "../../utils";
 
-export type TaskStepStatus =
-  "not-started" | "in-progress" | "completed" | "cannot-start-yet";
-
 /**
  * @summary A single step within an `ogds-task-list`.
  *
@@ -28,7 +25,8 @@ export type TaskStepStatus =
  */
 export class OgdsTaskListStep extends LitElement {
   @property({ reflect: true })
-  status: TaskStepStatus = "not-started";
+  status: "not-started" | "in-progress" | "completed" | "cannot-start-yet" =
+    "not-started";
 
   @property()
   url = "";
@@ -99,5 +97,7 @@ export class OgdsTaskListStep extends LitElement {
     `;
   }
 }
+
+export type TaskStepStatus = OgdsTaskListStep["status"];
 
 defineCustomElement("ogds-task-list-step", OgdsTaskListStep);

--- a/src/components/ogds-task-list/ogds-task-list-step.ts
+++ b/src/components/ogds-task-list/ogds-task-list-step.ts
@@ -19,7 +19,7 @@ import { defineCustomElement } from "../../utils";
  * @slot status-label - The status badge label. Defaults to the English label for the current status.
  * @slot blocked-message - Message shown when status is "cannot-start-yet". Defaults to "Not available until previous tasks are complete."
  *
- * @cssprop --ogds-task-list-step-border-color - Color of the top border divider. Defaults to gray-50.
+ * @cssprop [--ogds-task-list-step-border-color=var(--ogds-color-gray-50)] - Color of the top border divider.
  *
  * @element ogds-task-list-step
  */

--- a/src/components/ogds-task-list/ogds-task-list-step.ts
+++ b/src/components/ogds-task-list/ogds-task-list-step.ts
@@ -12,12 +12,12 @@ import { defineCustomElement } from "../../utils";
  * @attribute {string} status - Completion status. One of: not-started, in-progress, completed, cannot-start-yet.
  * @attribute {string} url - URL the task title links to. Not used when status is "cannot-start-yet".
  *
- * @slot title - The task title text.
- * @slot alert - Optional alert (e.g. a USWDS alert). Shown between the badge and description.
- * @slot description - Optional description text.
- * @slot saved-data - Optional summary of submitted data (e.g. a `<dl>`) shown below the badge.
- * @slot status-label - The status badge label. Defaults to the English label for the current status.
- * @slot blocked-message - Message shown when status is "cannot-start-yet". Defaults to "Not available until previous tasks are complete."
+ * @slot title - **Plain text.** The task title text.
+ * @slot alert - **HTML markup.** Optional alert (e.g. a USWDS alert). Shown between the badge and description.
+ * @slot description - **Plain text.** Optional description text.
+ * @slot saved-data - **HTML markup.** Optional summary of submitted data (e.g. a `<dl>`) shown below the badge.
+ * @slot status-label - **Plain text.** The status badge label. Defaults to the English label for the current status.
+ * @slot blocked-message - **Plain text.** Message shown when status is "cannot-start-yet". Defaults to "Not available until previous tasks are complete."
  *
  * @cssprop [--ogds-task-list-step-border-color=var(--ogds-color-gray-50)] - Color of the top border divider.
  *

--- a/src/components/ogds-task-list/ogds-task-list.stories.ts
+++ b/src/components/ogds-task-list/ogds-task-list.stories.ts
@@ -1,6 +1,7 @@
 import "./ogds-task-list";
 import "./ogds-task-list-step";
 import ComponentDocs from "./docs.mdx";
+import { html } from "lit";
 import { getStorybookHelpers } from "@wc-toolkit/storybook-helpers";
 import type { Args } from "storybook/internal/csf";
 

--- a/src/components/ogds-task-list/ogds-task-list.stories.ts
+++ b/src/components/ogds-task-list/ogds-task-list.stories.ts
@@ -1,52 +1,57 @@
-import { html } from "lit";
 import "./ogds-task-list";
 import "./ogds-task-list-step";
 import ComponentDocs from "./docs.mdx";
+import { getStorybookHelpers } from "@wc-toolkit/storybook-helpers";
+import type { Args } from "storybook/internal/csf";
+
+const { args, argTypes, template } = getStorybookHelpers("ogds-task-list", {
+  // Internal implementation methods aren't part of the public API.
+  excludeCategories: ["methods"],
+});
+
+const defaultSteps = `
+  <ogds-task-list-step status="completed" url="/step-1">
+    <span slot="title">Tell us about you</span>
+  </ogds-task-list-step>
+  <ogds-task-list-step status="in-progress" url="/step-2">
+    <span slot="title">Set up your employer profile</span>
+    <p slot="description">
+      Confirm your legal entity structure, employer details, and EIN.
+    </p>
+  </ogds-task-list-step>
+  <ogds-task-list-step status="not-started" url="/step-3">
+    <span slot="title">Enter the employer's address</span>
+    <p slot="description">Tell us where the business is located.</p>
+  </ogds-task-list-step>
+  <ogds-task-list-step status="cannot-start-yet">
+    <span slot="title">Submit your Maryland Resident Agent details</span>
+  </ogds-task-list-step>
+`;
 
 export default {
   title: "Components/Task List",
   component: "ogds-task-list",
   tags: ["alpha"],
+  args: {
+    ...args,
+    "instruction-slot": "Finish all tasks to submit your application.",
+    "default-slot": defaultSteps,
+  },
+  argTypes,
   parameters: {
     docs: {
       page: ComponentDocs,
     },
   },
+  render: (args: Args) => template(args),
 };
 
-export const Default = {
-  render: () => html`
-    <ogds-task-list>
-      <p slot="instruction">Finish all tasks to submit your application.</p>
-
-      <ogds-task-list-step status="completed" url="/step-1">
-        <span slot="title">Tell us about you</span>
-      </ogds-task-list-step>
-
-      <ogds-task-list-step status="in-progress" url="/step-2">
-        <span slot="title">Set up your employer profile</span>
-        <p slot="description">
-          Confirm your legal entity structure, employer details, and EIN.
-        </p>
-      </ogds-task-list-step>
-
-      <ogds-task-list-step status="not-started" url="/step-3">
-        <span slot="title">Enter the employer's address</span>
-        <p slot="description">Tell us where the business is located.</p>
-      </ogds-task-list-step>
-
-      <ogds-task-list-step status="cannot-start-yet">
-        <span slot="title">Submit your Maryland Resident Agent details</span>
-      </ogds-task-list-step>
-    </ogds-task-list>
-  `,
-};
+export const Default = {};
 
 export const AllStatuses = {
-  render: () => html`
-    <ogds-task-list>
-      <p slot="instruction">Each possible task state.</p>
-
+  args: {
+    "instruction-slot": "Each possible task state.",
+    "default-slot": `
       <ogds-task-list-step status="completed" url="/step-1">
         <span slot="title">Completed task</span>
         <dl slot="saved-data">
@@ -54,65 +59,36 @@ export const AllStatuses = {
           <dd>(410) 123-4567</dd>
         </dl>
       </ogds-task-list-step>
-
       <ogds-task-list-step status="in-progress" url="/step-2">
         <span slot="title">In progress task</span>
         <p slot="description">
           Short description explaining the value of completing this task.
         </p>
       </ogds-task-list-step>
-
       <ogds-task-list-step status="not-started" url="/step-3">
         <span slot="title">Not started task</span>
         <p slot="description">
           Short description explaining the value of completing this task.
         </p>
       </ogds-task-list-step>
-
       <ogds-task-list-step status="cannot-start-yet">
         <span slot="title">Cannot start yet task</span>
       </ogds-task-list-step>
-    </ogds-task-list>
-  `,
+    `,
+  },
 };
 
 export const Translated = {
-  render: () => html`
-    <ogds-task-list>
-      <span slot="counter-label">tareas completadas</span>
-      <p slot="instruction">
-        Complete todas las tareas para enviar su solicitud.
-      </p>
-
+  args: {
+    "counter-label-slot": "tareas completadas",
+    "instruction-slot": "Complete todas las tareas para enviar su solicitud.",
+    "default-slot": `
       <ogds-task-list-step status="completed" url="/paso-1">
         <span slot="title">Cuéntanos sobre ti</span>
       </ogds-task-list-step>
-
       <ogds-task-list-step status="not-started" url="/paso-2">
         <span slot="title">Configura tu perfil de empleador</span>
       </ogds-task-list-step>
-    </ogds-task-list>
-  `,
-};
-
-export const StepOnly = {
-  parameters: {
-    a11y: {
-      config: {
-        rules: [
-          // aria-required-parent fires because role="listitem" requires a parent
-          // list, but this story renders the step in isolation for design preview.
-          { id: "aria-required-parent", enabled: false },
-        ],
-      },
-    },
+    `,
   },
-  render: () => html`
-    <ogds-task-list-step status="in-progress" url="/some-task">
-      <span slot="title">Tell us about your employer</span>
-      <p slot="description">
-        We need a few details to verify your business registration.
-      </p>
-    </ogds-task-list-step>
-  `,
 };

--- a/src/components/ogds-task-list/ogds-task-list.stories.ts
+++ b/src/components/ogds-task-list/ogds-task-list.stories.ts
@@ -5,7 +5,6 @@ import { getStorybookHelpers } from "@wc-toolkit/storybook-helpers";
 import type { Args } from "storybook/internal/csf";
 
 const { args, argTypes, template } = getStorybookHelpers("ogds-task-list", {
-  // Internal implementation methods aren't part of the public API.
   excludeCategories: ["methods"],
 });
 

--- a/src/components/ogds-task-list/ogds-task-list.stories.ts
+++ b/src/components/ogds-task-list/ogds-task-list.stories.ts
@@ -1,7 +1,6 @@
 import "./ogds-task-list";
 import "./ogds-task-list-step";
 import ComponentDocs from "./docs.mdx";
-import { html } from "lit";
 import { getStorybookHelpers } from "@wc-toolkit/storybook-helpers";
 import type { Args } from "storybook/internal/csf";
 
@@ -47,10 +46,9 @@ export default {
 };
 
 export const Default = {
-  render: () => html`
-    <ogds-task-list>
-      <p slot="instruction">Finish all tasks to submit your application.</p>
-
+  args: {
+    "instruction-slot": "Finish all tasks to submit your application.",
+    "default-slot": `
       <ogds-task-list-step status="completed" url="/step-1">
         <span slot="title">Edit your profile</span>
         <dl slot="saved-data">
@@ -60,20 +58,17 @@ export const Default = {
           <dd>example@example.com</dd>
         </dl>
       </ogds-task-list-step>
-
       <ogds-task-list-step status="in-progress" url="/step-2">
         <span slot="title">Edit your address</span>
       </ogds-task-list-step>
-
       <ogds-task-list-step status="not-started" url="/step-3">
         <span slot="title">Submit additional supporting documents</span>
       </ogds-task-list-step>
-
       <ogds-task-list-step status="cannot-start-yet">
         <span slot="title">Sign contractual agreement</span>
       </ogds-task-list-step>
-    </ogds-task-list>
-  `,
+    `,
+  },
 };
 
 export const AllStatuses = {

--- a/src/components/ogds-task-list/ogds-task-list.ts
+++ b/src/components/ogds-task-list/ogds-task-list.ts
@@ -22,7 +22,7 @@ const headingTags = {
  * @slot instruction - Text shown below the task counter (e.g. "Finish all tasks to submit.").
  * @slot - One or more `<ogds-task-list-step>` elements.
  *
- * @cssprop --ogds-task-list-border-color - Color of the bottom border on the step list. Defaults to gray-50.
+ * @cssprop [--ogds-task-list-border-color=var(--ogds-color-gray-50)] - Color of the bottom border on the step list.
  *
  * @element ogds-task-list
  */

--- a/src/components/ogds-task-list/ogds-task-list.ts
+++ b/src/components/ogds-task-list/ogds-task-list.ts
@@ -32,7 +32,7 @@ export class OgdsTaskList extends LitElement {
    * @attr base-heading-level
    */
   @property({ type: Number, attribute: "base-heading-level" })
-  baseHeadingLevel: keyof typeof headingTags = 2;
+  baseHeadingLevel: number = 2;
 
   @state() private _completedCount = 0;
   @state() private _totalCount = 0;
@@ -60,7 +60,9 @@ export class OgdsTaskList extends LitElement {
   }
 
   render() {
-    const tag = headingTags[this.baseHeadingLevel] ?? headingTags[2];
+    const tag =
+      headingTags[this.baseHeadingLevel as keyof typeof headingTags] ??
+      headingTags[2];
     return html`
       <section aria-labelledby="counter">
         <div class="header">

--- a/src/components/ogds-task-list/ogds-task-list.ts
+++ b/src/components/ogds-task-list/ogds-task-list.ts
@@ -18,9 +18,9 @@ const headingTags = {
 /**
  * @summary A task progress list with a completion counter and slotted steps.
  *
- * @slot counter-label - The label after the computed "X of Y" count. Defaults to "tasks completed". Use an inline element (e.g. `<span>`).
- * @slot instruction - Text shown below the task counter (e.g. "Finish all tasks to submit.").
- * @slot - One or more `<ogds-task-list-step>` elements.
+ * @slot counter-label - **Plain text.** The label after the computed "X of Y" count. Defaults to "tasks completed". Use an inline element (e.g. `<span>`).
+ * @slot instruction - **Plain text.** Text shown below the task counter (e.g. "Finish all tasks to submit.").
+ * @slot - **HTML markup.** One or more `<ogds-task-list-step>` elements.
  *
  * @cssprop [--ogds-task-list-border-color=var(--ogds-color-gray-50)] - Color of the bottom border on the step list.
  *

--- a/storybook/index.css
+++ b/storybook/index.css
@@ -43,7 +43,7 @@
 
   pre,
   code {
-    font-size: initial;
+    font-size: inherit;
   }
 
   :where(p:not(.sb-anchor, .sb-unstyled, .sb-unstyled p)),

--- a/storybook/index.css
+++ b/storybook/index.css
@@ -1,7 +1,7 @@
 :root {
   background-color: var(--usa-color-white);
   color: var(--usa-color-gray-90);
-  color-scheme: light dark;
+  color-scheme: light;
   font-family:
     "Public Sans Web",
     -apple-system,


### PR DESCRIPTION
# Summary

Added better documentation for the Task List & Task List Step components and made several improvements to existing stories to better leverage Storybook's functionality.

## Problem statement

Prior to this PR, there was a lot of functionality we already configured Storybook for but weren't using. I didn't really notice this until we got a question about functionality I knew a component had and assumed was documented, but wasn't. In going back to address that gap, I noticed several other ways the docs could be improved:

- Storybook wasn't actually using the custom element manifest even though we had that integration set up
- Props in the stories weren't wired correctly to the components, so readers didn't get the benefit of being able to test different prop values directly in SB.
- Props that had enum values weren't properly reflecting as dropdowns in the docs

## Solution

In light of the many issues this PR addresses, there are several changes:

- Created a separate set of task list step stories, so that its props could be properly documented
- Ensured we were leveraging the `@wc-toolkit` storybook helpers to fix the integration with each component's CEM
- Rewire existing stories so they allow live editing of props.
- Slight tweak to enum-based fields to let them integrate with the relevant stories
- Also bumped the header & primary nav components from experimental to alpha, though there will be changes to the header in another PR soon

## Testing and review

There's no new functionality in any of the components (though there are a couple of code changes in order to support better SB integration), but do poke at the new docs and 
