### PR TITLE
Rearchitect header component

### DIFF
--- a/config/stylelint.config.mjs
+++ b/config/stylelint.config.mjs
@@ -3,6 +3,13 @@ export default {
   extends: ["stylelint-config-standard"],
   plugins: ["stylelint-order"],
   rules: {
+    "custom-property-pattern": [
+      "^_?[a-z][a-z0-9]*(-[a-z0-9]+)*$",
+      {
+        message:
+          "Custom properties must be kebab-case, optionally prefixed with _ to mark them private/internal (not a documented @cssprop, not meant for consumers to set).",
+      },
+    ],
     "declaration-block-no-redundant-longhand-properties": null,
     "no-descending-specificity": null,
     "no-duplicate-selectors": null,

--- a/src/components/ogds-header/docs.mdx
+++ b/src/components/ogds-header/docs.mdx
@@ -56,6 +56,16 @@ Optional slots that receive no content aren't rendered. Omit them rather than pa
 Below the desktop breakpoint (64rem), the primary and secondary nav collapse into a `<dialog>` drawer that slides in from the right when the menu button is pressed.
 This includes a backdrop, a focus trap, and Escape-to-close, all native to `<dialog>`.
 
+## Full-bleed rows
+
+At desktop widths, `--ogds-header-navbar-background-color`, `--ogds-header-info-background-color`, and `--ogds-header-nav-primary-row-background-color` all paint edge-to-edge automatically. A background color fills the full viewport width while the row's own content stays inside the `--ogds-header-max-width` column, no extra markup or opt-in required.
+
+`--ogds-header-nav-secondary-background-color` bleeds on the side facing away from whatever it shares that row with (the navbar in `extended`, the primary nav in `basic`). When it's unset, it defaults to that other row's color, so setting only `--ogds-header-navbar-background-color` (or, in `basic`, only `--ogds-header-nav-primary-row-background-color`) already gives you one seamless band with no further configuration. Set `--ogds-header-nav-secondary-background-color` explicitly if you want an intentional two-tone split instead. If you need finer-grained control than the built-in custom properties offer, every structural piece is also exposed via a shadow part (targeted with `::part()` in the CSS): `part="navbar"`, `part="info"`, `part="nav-primary-row"`, `part="nav-secondary"`, `part="menu-btn"`, `part="nav-close"`, `part="logo"`, `part="notifications"`.
+
+## Sizing model
+
+`--ogds-header-max-width` matches the [`content-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/box-sizing) convention of a USWDS `.grid-container`: the content column itself is `max-width` wide, and `--ogds-header-padding-inline` is added _outside_ that (so the rendered width caps at `max-width + 2 * padding-inline`). Reuse the same `max-width` value you use for your page's `.grid-container` to line the two up exactly, with no extra math. Refer to the [USWDS documentation](https://designsystem.digital.gov/utilities/layout-grid/) for `grid-container` widths.
+
 ---
 
 ## More Examples

--- a/src/components/ogds-header/docs.mdx
+++ b/src/components/ogds-header/docs.mdx
@@ -51,6 +51,10 @@ Optional slots that receive no content aren't rendered. Omit them rather than pa
 - `extended` (default) — secondary nav appears in its own area, aligned with the logo, at desktop widths.
 - `basic` — secondary nav sits inline alongside the primary nav instead.
 
+## `icon` attribute
+
+Add the boolean `icon` attribute to show a hamburger icon on the menu button, in addition to its "Menu" label. Sized with `--ogds-header-icon-menu-size`.
+
 ## Responsive behavior
 
 Below the desktop breakpoint (64rem), the primary and secondary nav collapse into a `<dialog>` drawer that slides in from the right when the menu button is pressed.

--- a/src/components/ogds-header/ogds-header.css
+++ b/src/components/ogds-header/ogds-header.css
@@ -22,20 +22,21 @@
    * parse a `var()` with a fallback in a `min()`. Same bug as the one
    * causing the FIXME re: the accordion css in the eslint config
    */
-  --_ogds-header-max-width-or-100vw: var(--ogds-header-max-width, 100vw);
+  --_ogds-header-max-width-or-100pct: var(--ogds-header-max-width, 100%);
 
   /*
-   * Private (leading underscore, not a documented @cssprop 🤫, so documenting here):
-   * the distance from the viewport edge to where a centered column of
-   * --ogds-header-max-width would sit. Rows that need a full-bleed
-   * background cancel this out via a negative margin and reapply it as padding, so the row's
-   * border/background box reaches the viewport edge while its content stays
-   * exactly where it was. min() keeps this at 0 rather than going negative on
-   * a viewport narrower than max-width.
+   * Private (not a documented @cssprop 🤫): the distance
+   * from this row's own edge to where a centered column of
+   * --ogds-header-max-width would sit. Workaround for rows that
+   * share physical space with a sibling (.navbar-row-inner and
+   * .nav-secondary, when they're on the same row. See the
+   * @media (width >= 64rem) block below). A row that gets the whole width
+   * to itself just uses max-width + margin: auto + padding-inline
+   * directly (see e.g. .info-row-inner, .primary-row-inner).
    */
   --_ogds-header-gutter: max(
     var(--ogds-header-padding-inline, 0),
-    calc((100vw - min(100vw, var(--_ogds-header-max-width-or-100vw))) / 2)
+    calc((100% - min(100%, var(--_ogds-header-max-width-or-100pct))) / 2)
   );
 
   display: block;
@@ -49,46 +50,84 @@
 }
 
 .content {
-  /*
-   * explicitly opt back into content-box to align with a USWDS grid container
-   */
-  box-sizing: content-box;
-  display: grid;
-  margin-inline: auto;
-  max-width: var(--ogds-header-max-width, none);
-  padding-inline: var(--ogds-header-padding-inline, 0);
+  display: flex;
+  flex-direction: column;
   row-gap: var(--ogds-header-row-gap);
 }
 
-.navbar {
-  align-items: center;
+.navbar-row {
   background-color: var(--ogds-header-navbar-background-color, transparent);
+  display: flex;
+}
+
+.navbar-row-inner {
+  align-items: center;
+  box-sizing: content-box;
   display: flex;
   gap: var(--ogds-spacing-2, 1rem);
   justify-content: space-between;
+  margin-inline: auto;
+  max-width: var(--ogds-header-max-width, none);
+  padding-block: var(--ogds-spacing-3, 1.5rem);
+  padding-inline: var(--ogds-header-padding-inline, 0);
+  width: 100%;
 }
 
-.nav-primary-row {
+.info-row {
+  background-color: var(--ogds-header-info-background-color, transparent);
+  border-block: 1px solid var(--ogds-header-divider-color);
+}
+
+.info-row-inner {
+  box-sizing: content-box;
+  font-size: var(--ogds-theme-type-scale-2xs, 0.875rem);
+  margin-inline: auto;
+  max-width: var(--ogds-header-max-width, none);
+  padding-block: var(--ogds-spacing-05, 0.25rem);
+  padding-inline: var(--ogds-header-padding-inline, 0);
+  width: 100%;
+}
+
+.nav-secondary {
+  display: flex;
+  flex: 0 0 auto;
+  gap: var(--ogds-spacing-1, 0.5rem);
+}
+
+/*
+ * Primary nav row (desktop only - the equivalent structure below the
+ * desktop breakpoint lives inside <dialog>, see .nav-primary-row further
+ * down). Same "no align-items" reasoning as .navbar-row above.
+ */
+.primary-row {
   background-color: var(
     --ogds-header-nav-primary-row-background-color,
     transparent
   );
+  border-block-start: 1px solid
+    var(
+      --ogds-header-nav-primary-row-divider-color,
+      var(--ogds-header-divider-color)
+    );
   display: flex;
-  flex-direction: column;
+}
+
+.primary-row-inner {
+  align-items: center;
+  box-sizing: content-box;
+  display: flex;
   gap: var(--ogds-spacing-2, 1rem);
+  justify-content: space-between;
+  margin-inline: auto;
+  max-width: var(--ogds-header-max-width, none);
+  padding-inline: var(--ogds-header-padding-inline, 0);
+  width: 100%;
 }
 
 .notifications {
   align-items: center;
   display: flex;
   margin-inline-start: auto;
-}
-
-.info {
-  background-color: var(--ogds-header-info-background-color, transparent);
-  border-block: 1px solid var(--ogds-header-divider-color);
-  font-size: var(--ogds-theme-type-scale-2xs, 0.875rem);
-  padding-block: var(--ogds-spacing-05, 0.25rem);
 }
 
 .menu-btn {
@@ -128,7 +167,6 @@
   border: none;
   color: inherit;
   cursor: pointer;
-  display: none;
   flex: none;
   height: var(--ogds-size-touch-target, 2.5rem);
   width: var(--ogds-size-touch-target, 2.5rem);
@@ -147,14 +185,25 @@
   }
 }
 
+/*
+ * <dialog> only ever exists in the DOM below the desktop breakpoint (see
+ * render() in ogds-header.ts) so the styles don't need to account for it
+ * at desktop width
+ */
 .nav {
   background-color: var(--ogds-header-nav-background-color);
   border: none;
   color: inherit;
+  height: 100%;
+  inset-block: 0;
+  inset-inline: auto 0;
   margin: 0;
   max-height: none;
   max-width: none;
   padding: var(--ogds-spacing-2, 1rem);
+  position: fixed;
+  translate: 100% 0;
+  width: var(--ogds-header-drawer-width);
 
   &.no-transition {
     transition: none;
@@ -167,6 +216,22 @@
   &[open] {
     display: flex;
     flex-direction: column;
+    translate: 0 0;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .nav {
+    transition:
+      translate 0.3s ease-in-out,
+      display 0.3s ease-in-out allow-discrete,
+      overlay 0.3s ease-in-out allow-discrete;
+  }
+
+  @starting-style {
+    .nav[open] {
+      translate: 100% 0;
+    }
   }
 }
 
@@ -174,14 +239,22 @@
   display: block;
 }
 
-.nav-secondary {
+.nav > .nav-secondary {
   background-color: var(
     --ogds-header-nav-secondary-background-color,
     transparent
   );
-  display: flex;
   flex-direction: column;
-  gap: var(--ogds-spacing-1, 0.5rem);
+}
+
+.nav-primary-row {
+  border-block-start: 1px solid
+    var(
+      --ogds-header-nav-primary-row-divider-color,
+      var(--ogds-header-divider-color)
+    );
+  margin-block-start: var(--ogds-spacing-2, 1rem);
+  padding-block-start: var(--ogds-spacing-2, 1rem);
 }
 
 @media (width < 64rem) {
@@ -189,11 +262,7 @@
     display: inline-flex;
   }
 
-  /*
-   * Decouples the menu button's own edge inset from the logo's.
-   */
-  .navbar {
-    margin-inline-end: calc(-1 * var(--ogds-header-padding-inline, 0));
+  .navbar-row-inner {
     padding-inline-end: var(
       --ogds-header-menu-btn-padding-inline-end,
       var(--ogds-header-padding-inline, 0)
@@ -203,172 +272,19 @@
   .nav-close {
     display: block;
   }
-
-  .nav {
-    height: 100%;
-    inset-block: 0;
-    inset-inline: auto 0;
-    position: fixed;
-    translate: 100% 0;
-    width: var(--ogds-header-drawer-width);
-  }
-
-  .nav[open] {
-    translate: 0 0;
-  }
-
-  .nav-primary-row {
-    border-block-start: 1px solid
-      var(
-        --ogds-header-nav-primary-row-divider-color,
-        var(--ogds-header-divider-color)
-      );
-    margin-block-start: var(--ogds-spacing-2, 1rem);
-    padding-block-start: var(--ogds-spacing-2, 1rem);
-  }
-
-  @media (prefers-reduced-motion: no-preference) {
-    .nav {
-      transition:
-        translate 0.3s ease-in-out,
-        display 0.3s ease-in-out allow-discrete,
-        overlay 0.3s ease-in-out allow-discrete;
-    }
-
-    @starting-style {
-      .nav[open] {
-        translate: 100% 0;
-      }
-    }
-  }
 }
 
 @media (width >= 64rem) {
-  .nav {
-    padding: 0;
-    position: static;
-    width: 100%;
-  }
-
-  /*
-   * .info always occupies its own full-width row in both variants
-   */
-  .info {
-    margin-inline: calc(-1 * var(--_ogds-header-gutter));
-    padding-inline: var(--_ogds-header-gutter);
-  }
-
-  .nav-primary-row {
-    align-items: center;
-    flex-direction: row;
-    justify-content: space-between;
-  }
-
-  .nav-secondary {
-    align-items: center;
-    flex-direction: row;
-  }
-
-  :host([variant="basic"]) .nav[open] {
-    align-items: center;
-    flex-direction: row;
-  }
-
-  /*
-   * Basic, .navbar (logo area) is alone in its row so it bleeds on both sides
-   */
-  :host([variant="basic"]) .navbar {
-    margin-inline: calc(-1 * var(--_ogds-header-gutter));
-    padding-inline: var(--_ogds-header-gutter);
-  }
-
-  /* What follows here is mostly how we handle the full-bleed behavior
-   * for the several variants the component supports
-   * ("bleed" both in terms of the layout as well as the single prop for background colors)
-   * */
-
-  /*
-   * Basic: .nav-secondary sits at the start (left side, inline-start) of its row,
-   * so only its start edge reaches the viewport.
-   *
-   * re: background-color, falls back to .nav-primary-row's: without this, setting
-   * only --ogds-header-nav-primary-row-background-color would leave a
-   * transparent gap where .nav-secondary sits, showing the page behind it
-   * instead of one continuous band. Set --ogds-header-nav-secondary-background-color
-   * to intentionally make it a different color
-   */
-  :host([variant="basic"]) .nav-secondary {
-    align-self: stretch;
-    background-color: var(
-      --ogds-header-nav-secondary-background-color,
-      var(--ogds-header-nav-primary-row-background-color, transparent)
-    );
-    margin-inline-start: calc(-1 * var(--_ogds-header-gutter));
-    padding-inline-start: var(--_ogds-header-gutter);
-  }
-
-  /*
-   * Basic variant only needs to account for vw on the right (inline-end) side
-   */
-  :host([variant="basic"]) .nav-primary-row {
-    align-self: stretch;
+  .navbar-row:has(> .nav-secondary) .navbar-row-inner {
     flex: 1 1 auto;
-    margin-inline-end: calc(-1 * var(--_ogds-header-gutter));
-    margin-inline-start: var(--ogds-spacing-2, 1rem);
-    padding-inline-end: var(--_ogds-header-gutter);
-  }
-
-  :host([variant="extended"]) .content {
-    grid-template-areas:
-      "navbar secondary"
-      "info info"
-      "primary primary";
-    grid-template-columns: 1fr auto;
-  }
-
-  /*
-   * Extended variant: .navbar (logo area) only needs to account for vw
-   * on the left (inline-start) side
-   */
-  :host([variant="extended"]) .navbar {
-    align-self: stretch;
-    grid-area: navbar;
-    margin-inline-start: calc(-1 * var(--_ogds-header-gutter));
-    padding-block: var(--ogds-spacing-3, 1.5rem);
+    margin-inline: 0;
+    max-width: none;
+    padding-inline: 0;
     padding-inline-start: var(--_ogds-header-gutter);
+    width: auto;
   }
 
-  :host([variant="extended"]) .info {
-    border-block-end: none;
-    grid-area: info;
-  }
-
-  :host([variant="extended"]) .nav[open] {
-    display: contents;
-  }
-
-  /*
-   * In extended, .nav-primary-row spans the full grid row (i.e. bleeds both sides)
-   */
-  :host([variant="extended"]) .nav-primary-row {
-    border-block-start: 1px solid
-      var(
-        --ogds-header-nav-primary-row-divider-color,
-        var(--ogds-header-divider-color)
-      );
-    grid-area: primary;
-    margin-inline: calc(-1 * var(--_ogds-header-gutter));
-    padding-inline: var(--_ogds-header-gutter);
-  }
-
-  /*
-   * Extended variant: .nav-secondary is opposite .navbar so only its right/inline-end
-   * edge reaches the viewport.
-   * Its background-color needs to fall back to .navbar's so
-   * --ogds-header-navbar-background-color doesn't leave a transparent gap
-   * where .nav-secondary sits.
-   */
-  :host([variant="extended"]) .nav-secondary {
+  .navbar-row > .nav-secondary {
     align-items: flex-end;
     align-self: stretch;
     background-color: var(
@@ -376,11 +292,27 @@
       var(--ogds-header-navbar-background-color, transparent)
     );
     flex-direction: column;
-    grid-area: secondary;
     justify-content: center;
-    justify-self: end;
-    margin-inline-end: calc(-1 * var(--_ogds-header-gutter));
     padding-inline-end: var(--_ogds-header-gutter);
+  }
+
+  .primary-row > .nav-secondary {
+    align-items: center;
+    align-self: stretch;
+    background-color: var(
+      --ogds-header-nav-secondary-background-color,
+      var(--ogds-header-nav-primary-row-background-color, transparent)
+    );
+    padding-inline-start: var(--_ogds-header-gutter);
+  }
+
+  .primary-row:has(> .nav-secondary) .primary-row-inner {
+    flex: 1 1 auto;
+    margin-inline: 0;
+    max-width: none;
+    padding-inline: 0;
+    padding-inline-end: var(--_ogds-header-gutter);
+    width: auto;
   }
 }
 

--- a/src/components/ogds-header/ogds-header.css
+++ b/src/components/ogds-header/ogds-header.css
@@ -253,12 +253,8 @@
    * .info always occupies its own full-width row in both variants
    */
   .info {
-    margin-inline: calc(
-      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
-    );
-    padding-inline: calc(
-      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
-    );
+    margin-inline: calc(-1 * var(--_ogds-header-gutter));
+    padding-inline: var(--_ogds-header-gutter);
   }
 
   .nav-primary-row {
@@ -281,12 +277,8 @@
    * Basic, .navbar (logo area) is alone in its row so it bleeds on both sides
    */
   :host([variant="basic"]) .navbar {
-    margin-inline: calc(
-      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
-    );
-    padding-inline: calc(
-      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
-    );
+    margin-inline: calc(-1 * var(--_ogds-header-gutter));
+    padding-inline: var(--_ogds-header-gutter);
   }
 
   /* What follows here is mostly how we handle the full-bleed behavior
@@ -309,12 +301,8 @@
       --ogds-header-nav-secondary-background-color,
       var(--ogds-header-nav-primary-row-background-color, transparent)
     );
-    margin-inline-start: calc(
-      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
-    );
-    padding-inline-start: calc(
-      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
-    );
+    margin-inline-start: calc(-1 * var(--_ogds-header-gutter));
+    padding-inline-start: var(--_ogds-header-gutter);
   }
 
   /*
@@ -322,13 +310,9 @@
    */
   :host([variant="basic"]) .nav-primary-row {
     flex: 1 1 auto;
-    margin-inline-end: calc(
-      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
-    );
+    margin-inline-end: calc(-1 * var(--_ogds-header-gutter));
     margin-inline-start: var(--ogds-spacing-2, 1rem);
-    padding-inline-end: calc(
-      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
-    );
+    padding-inline-end: var(--_ogds-header-gutter);
   }
 
   :host([variant="extended"]) .content {
@@ -346,13 +330,9 @@
   :host([variant="extended"]) .navbar {
     align-self: center;
     grid-area: navbar;
-    margin-inline-start: calc(
-      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
-    );
+    margin-inline-start: calc(-1 * var(--_ogds-header-gutter));
     padding-block: var(--ogds-spacing-3, 1.5rem);
-    padding-inline-start: calc(
-      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
-    );
+    padding-inline-start: var(--_ogds-header-gutter);
   }
 
   :host([variant="extended"]) .info {
@@ -374,12 +354,8 @@
         var(--ogds-header-divider-color)
       );
     grid-area: primary;
-    margin-inline: calc(
-      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
-    );
-    padding-inline: calc(
-      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
-    );
+    margin-inline: calc(-1 * var(--_ogds-header-gutter));
+    padding-inline: var(--_ogds-header-gutter);
   }
 
   /*
@@ -399,12 +375,8 @@
     flex-direction: column;
     grid-area: secondary;
     justify-self: end;
-    margin-inline-end: calc(
-      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
-    );
-    padding-inline-end: calc(
-      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
-    );
+    margin-inline-end: calc(-1 * var(--_ogds-header-gutter));
+    padding-inline-end: var(--_ogds-header-gutter);
   }
 }
 

--- a/src/components/ogds-header/ogds-header.css
+++ b/src/components/ogds-header/ogds-header.css
@@ -297,6 +297,7 @@
    * to intentionally make it a different color
    */
   :host([variant="basic"]) .nav-secondary {
+    align-self: stretch;
     background-color: var(
       --ogds-header-nav-secondary-background-color,
       var(--ogds-header-nav-primary-row-background-color, transparent)
@@ -309,6 +310,7 @@
    * Basic variant only needs to account for vw on the right (inline-end) side
    */
   :host([variant="basic"]) .nav-primary-row {
+    align-self: stretch;
     flex: 1 1 auto;
     margin-inline-end: calc(-1 * var(--_ogds-header-gutter));
     margin-inline-start: var(--ogds-spacing-2, 1rem);
@@ -328,7 +330,7 @@
    * on the left (inline-start) side
    */
   :host([variant="extended"]) .navbar {
-    align-self: center;
+    align-self: stretch;
     grid-area: navbar;
     margin-inline-start: calc(-1 * var(--_ogds-header-gutter));
     padding-block: var(--ogds-spacing-3, 1.5rem);
@@ -359,21 +361,22 @@
   }
 
   /*
-   * Extended variant: .nav-secondary is opposite .navbar so only its right/inline-end 
+   * Extended variant: .nav-secondary is opposite .navbar so only its right/inline-end
    * edge reaches the viewport.
    * Its background-color needs to fall back to .navbar's so
    * --ogds-header-navbar-background-color doesn't leave a transparent gap
-   * where .nav-secondary sits
+   * where .nav-secondary sits.
    */
   :host([variant="extended"]) .nav-secondary {
     align-items: flex-end;
-    align-self: center;
+    align-self: stretch;
     background-color: var(
       --ogds-header-nav-secondary-background-color,
       var(--ogds-header-navbar-background-color, transparent)
     );
     flex-direction: column;
     grid-area: secondary;
+    justify-content: center;
     justify-self: end;
     margin-inline-end: calc(-1 * var(--_ogds-header-gutter));
     padding-inline-end: var(--_ogds-header-gutter);

--- a/src/components/ogds-header/ogds-header.css
+++ b/src/components/ogds-header/ogds-header.css
@@ -33,8 +33,9 @@
    * exactly where it was. min() keeps this at 0 rather than going negative on
    * a viewport narrower than max-width.
    */
-  --_ogds-header-gutter: calc(
-    (100vw - min(100vw, var(--_ogds-header-max-width-or-100vw))) / 2
+  --_ogds-header-gutter: max(
+    var(--ogds-header-padding-inline, 0),
+    calc((100vw - min(100vw, var(--_ogds-header-max-width-or-100vw))) / 2)
   );
 
   display: block;

--- a/src/components/ogds-header/ogds-header.css
+++ b/src/components/ogds-header/ogds-header.css
@@ -17,6 +17,26 @@
   --ogds-header-overlay-color: rgb(0 0 0 / 70%);
   --ogds-header-row-gap: var(--ogds-spacing-2, 1rem);
 
+  /*
+   * Workaround needed for --_ogds-header-gutter below. eslint/css can't
+   * parse a `var()` with a fallback in a `min()`. Same bug as the one
+   * causing the FIXME re: the accordion css in the eslint config
+   */
+  --_ogds-header-max-width-or-100vw: var(--ogds-header-max-width, 100vw);
+
+  /*
+   * Private (leading underscore, not a documented @cssprop 🤫, so documenting here):
+   * the distance from the viewport edge to where a centered column of
+   * --ogds-header-max-width would sit. Rows that need a full-bleed
+   * background cancel this out via a negative margin and reapply it as padding, so the row's
+   * border/background box reaches the viewport edge while its content stays
+   * exactly where it was. min() keeps this at 0 rather than going negative on
+   * a viewport narrower than max-width.
+   */
+  --_ogds-header-gutter: calc(
+    (100vw - min(100vw, var(--_ogds-header-max-width-or-100vw))) / 2
+  );
+
   display: block;
   font-family: var(--ogds-header-font-family);
 }
@@ -28,6 +48,10 @@
 }
 
 .content {
+  /*
+   * explicitly opt back into content-box to align with a USWDS grid container
+   */
+  box-sizing: content-box;
   display: grid;
   margin-inline: auto;
   max-width: var(--ogds-header-max-width, none);
@@ -164,6 +188,17 @@
     display: inline-flex;
   }
 
+  /*
+   * Decouples the menu button's own edge inset from the logo's.
+   */
+  .navbar {
+    margin-inline-end: calc(-1 * var(--ogds-header-padding-inline, 0));
+    padding-inline-end: var(
+      --ogds-header-menu-btn-padding-inline-end,
+      var(--ogds-header-padding-inline, 0)
+    );
+  }
+
   .nav-close {
     display: block;
   }
@@ -182,7 +217,11 @@
   }
 
   .nav-primary-row {
-    border-block-start: 1px solid var(--ogds-header-divider-color);
+    border-block-start: 1px solid
+      var(
+        --ogds-header-nav-primary-row-divider-color,
+        var(--ogds-header-divider-color)
+      );
     margin-block-start: var(--ogds-spacing-2, 1rem);
     padding-block-start: var(--ogds-spacing-2, 1rem);
   }
@@ -210,6 +249,18 @@
     width: 100%;
   }
 
+  /*
+   * .info always occupies its own full-width row in both variants
+   */
+  .info {
+    margin-inline: calc(
+      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
+    );
+    padding-inline: calc(
+      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
+    );
+  }
+
   .nav-primary-row {
     align-items: center;
     flex-direction: row;
@@ -226,9 +277,58 @@
     flex-direction: row;
   }
 
+  /*
+   * Basic, .navbar (logo area) is alone in its row so it bleeds on both sides
+   */
+  :host([variant="basic"]) .navbar {
+    margin-inline: calc(
+      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
+    );
+    padding-inline: calc(
+      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
+    );
+  }
+
+  /* What follows here is mostly how we handle the full-bleed behavior
+   * for the several variants the component supports
+   * ("bleed" both in terms of the layout as well as the single prop for background colors)
+   * */
+
+  /*
+   * Basic: .nav-secondary sits at the start (left side, inline-start) of its row,
+   * so only its start edge reaches the viewport.
+   *
+   * re: background-color, falls back to .nav-primary-row's: without this, setting
+   * only --ogds-header-nav-primary-row-background-color would leave a
+   * transparent gap where .nav-secondary sits, showing the page behind it
+   * instead of one continuous band. Set --ogds-header-nav-secondary-background-color
+   * to intentionally make it a different color
+   */
+  :host([variant="basic"]) .nav-secondary {
+    background-color: var(
+      --ogds-header-nav-secondary-background-color,
+      var(--ogds-header-nav-primary-row-background-color, transparent)
+    );
+    margin-inline-start: calc(
+      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
+    );
+    padding-inline-start: calc(
+      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
+    );
+  }
+
+  /*
+   * Basic variant only needs to account for vw on the right (inline-end) side
+   */
   :host([variant="basic"]) .nav-primary-row {
     flex: 1 1 auto;
+    margin-inline-end: calc(
+      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
+    );
     margin-inline-start: var(--ogds-spacing-2, 1rem);
+    padding-inline-end: calc(
+      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
+    );
   }
 
   :host([variant="extended"]) .content {
@@ -239,10 +339,20 @@
     grid-template-columns: 1fr auto;
   }
 
+  /*
+   * Extended variant: .navbar (logo area) only needs to account for vw
+   * on the left (inline-start) side
+   */
   :host([variant="extended"]) .navbar {
     align-self: center;
     grid-area: navbar;
+    margin-inline-start: calc(
+      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
+    );
     padding-block: var(--ogds-spacing-3, 1.5rem);
+    padding-inline-start: calc(
+      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
+    );
   }
 
   :host([variant="extended"]) .info {
@@ -254,17 +364,47 @@
     display: contents;
   }
 
+  /*
+   * In extended, .nav-primary-row spans the full grid row (i.e. bleeds both sides)
+   */
   :host([variant="extended"]) .nav-primary-row {
-    border-block-start: 1px solid var(--ogds-header-divider-color);
+    border-block-start: 1px solid
+      var(
+        --ogds-header-nav-primary-row-divider-color,
+        var(--ogds-header-divider-color)
+      );
     grid-area: primary;
+    margin-inline: calc(
+      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
+    );
+    padding-inline: calc(
+      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
+    );
   }
 
+  /*
+   * Extended variant: .nav-secondary is opposite .navbar so only its right/inline-end 
+   * edge reaches the viewport.
+   * Its background-color needs to fall back to .navbar's so
+   * --ogds-header-navbar-background-color doesn't leave a transparent gap
+   * where .nav-secondary sits
+   */
   :host([variant="extended"]) .nav-secondary {
     align-items: flex-end;
     align-self: center;
+    background-color: var(
+      --ogds-header-nav-secondary-background-color,
+      var(--ogds-header-navbar-background-color, transparent)
+    );
     flex-direction: column;
     grid-area: secondary;
     justify-self: end;
+    margin-inline-end: calc(
+      -1 * (var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0))
+    );
+    padding-inline-end: calc(
+      var(--_ogds-header-gutter) + var(--ogds-header-padding-inline, 0)
+    );
   }
 }
 

--- a/src/components/ogds-header/ogds-header.spec.ts
+++ b/src/components/ogds-header/ogds-header.spec.ts
@@ -100,7 +100,7 @@ function simulateSlotChange(
   )!;
   vi.spyOn(slot, "assignedNodes").mockReturnValue(nodes);
   slot.dispatchEvent(new Event("slotchange", { bubbles: true }));
-  return slot.closest<HTMLElement>("[part]")!;
+  return slot.closest<HTMLElement>("[data-hide-when-empty]")!;
 }
 
 beforeEach(() => {

--- a/src/components/ogds-header/ogds-header.spec.ts
+++ b/src/components/ogds-header/ogds-header.spec.ts
@@ -10,7 +10,7 @@ import { OgdsHeader } from "./ogds-header";
 /**
  * jsdom doesn't implement the imperative <dialog> API at all, so polyfill
  * just enough of it (open state, the close event, and :modal matching) for
- * the component's viewport-sync logic to run without throwing.
+ * the component's drawer logic to run without throwing.
  *
  * Tracking issue for this, which is also where the polyfill idea came from
  * https://github.com/jsdom/jsdom/issues/3294
@@ -100,7 +100,7 @@ function simulateSlotChange(
   )!;
   vi.spyOn(slot, "assignedNodes").mockReturnValue(nodes);
   slot.dispatchEvent(new Event("slotchange", { bubbles: true }));
-  return slot.parentElement as HTMLElement;
+  return slot.closest<HTMLElement>("[part]")!;
 }
 
 beforeEach(() => {
@@ -143,47 +143,59 @@ describe("variant", () => {
   });
 });
 
-describe("viewport sync", () => {
-  it("opens the nav non-modally at desktop widths", async () => {
+describe("desktop/mobile structure", () => {
+  it("never renders a <dialog> at desktop widths", async () => {
     mockMatchMedia(true);
     const el = mount();
     await el.updateComplete;
-    const dialog = el.shadowRoot!.querySelector("dialog")!;
-    expect(dialog.open).toBe(true);
-    expect(dialog.matches(":modal")).toBe(false);
+    expect(el.shadowRoot!.querySelector("dialog")).toBeNull();
+    expect(el.shadowRoot!.querySelector(".primary-row")).not.toBeNull();
   });
 
-  it("leaves the nav closed below the desktop breakpoint", async () => {
+  it("renders a closed <dialog> at mobile widths", async () => {
     mockMatchMedia(false);
     const el = mount();
     await el.updateComplete;
-    const dialog = el.shadowRoot!.querySelector("dialog")!;
-    expect(dialog.open).toBe(false);
+    const dialog = el.shadowRoot!.querySelector("dialog");
+    expect(dialog).not.toBeNull();
+    expect(dialog!.open).toBe(false);
   });
 
-  it("closes a modally-open nav and reopens it non-modally when resizing to desktop", async () => {
+  it("closes an open modal drawer and removes it from the DOM when resizing to desktop", async () => {
     const media = mockMatchMedia(false);
     const el = mount();
     await el.updateComplete;
     const dialog = el.shadowRoot!.querySelector("dialog")!;
     dialog.showModal();
+    expect(dialog.open).toBe(true);
 
     media.setMatches(true);
-
-    expect(dialog.open).toBe(true);
-    expect(dialog.matches(":modal")).toBe(false);
-  });
-
-  it("closes a non-modally-open nav when resizing below desktop", async () => {
-    const media = mockMatchMedia(true);
-    const el = mount();
     await el.updateComplete;
-    const dialog = el.shadowRoot!.querySelector("dialog")!;
-    expect(dialog.open).toBe(true);
-
-    media.setMatches(false);
 
     expect(dialog.open).toBe(false);
+    expect(el.shadowRoot!.querySelector("dialog")).toBeNull();
+  });
+
+  it("renders nav-secondary alongside the navbar in the extended variant", async () => {
+    mockMatchMedia(true);
+    const el = mount('<ogds-header variant="extended"></ogds-header>');
+    await el.updateComplete;
+    const navbarRow = el.shadowRoot!.querySelector(".navbar-row");
+    expect(navbarRow!.querySelector(".nav-secondary")).not.toBeNull();
+    expect(
+      el.shadowRoot!.querySelector(".primary-row .nav-secondary"),
+    ).toBeNull();
+  });
+
+  it("renders nav-secondary alongside the primary row in the basic variant", async () => {
+    mockMatchMedia(true);
+    const el = mount('<ogds-header variant="basic"></ogds-header>');
+    await el.updateComplete;
+    const primaryRow = el.shadowRoot!.querySelector(".primary-row");
+    expect(primaryRow!.querySelector(".nav-secondary")).not.toBeNull();
+    expect(
+      el.shadowRoot!.querySelector(".navbar-row .nav-secondary"),
+    ).toBeNull();
   });
 });
 
@@ -231,7 +243,7 @@ describe("menu button", () => {
     expect(dialog.open).toBe(false);
   });
 
-  it("resets aria-expanded when the nav is closed below desktop", async () => {
+  it("resets aria-expanded when the nav is closed", async () => {
     mockMatchMedia(false);
     const el = mount();
     await el.updateComplete;
@@ -242,19 +254,6 @@ describe("menu button", () => {
     dialog.close();
 
     expect(menuBtn.getAttribute("aria-expanded")).toBe("false");
-  });
-
-  it("does not reset aria-expanded from a desktop close", async () => {
-    mockMatchMedia(true);
-    const el = mount();
-    await el.updateComplete;
-    const dialog = el.shadowRoot!.querySelector("dialog")!;
-    const menuBtn = el.shadowRoot!.querySelector(".menu-btn") as HTMLElement;
-    menuBtn.setAttribute("aria-expanded", "true");
-
-    dialog.close();
-
-    expect(menuBtn.getAttribute("aria-expanded")).toBe("true");
   });
 });
 
@@ -289,7 +288,7 @@ describe("optional slots", () => {
   it("hides the info row until content is slotted", async () => {
     const el = mount();
     await el.updateComplete;
-    const wrapper = el.shadowRoot!.querySelector(".info") as HTMLElement;
+    const wrapper = el.shadowRoot!.querySelector(".info-row") as HTMLElement;
     expect(wrapper.hidden).toBe(true);
 
     simulateSlotChange(el, "info", [document.createElement("div")]);

--- a/src/components/ogds-header/ogds-header.spec.ts
+++ b/src/components/ogds-header/ogds-header.spec.ts
@@ -309,4 +309,19 @@ describe("optional slots", () => {
     simulateSlotChange(el, "notifications", [document.createElement("div")]);
     expect(wrapper.hidden).toBe(false);
   });
+
+  it("hides nav-secondary until content is slotted", async () => {
+    const el = mount();
+    await el.updateComplete;
+    const wrapper = el.shadowRoot!.querySelector(
+      ".nav-secondary",
+    ) as HTMLElement;
+    expect(wrapper.hidden).toBe(true);
+
+    simulateSlotChange(el, "nav-secondary", [document.createElement("div")]);
+    expect(wrapper.hidden).toBe(false);
+
+    simulateSlotChange(el, "nav-secondary", []);
+    expect(wrapper.hidden).toBe(true);
+  });
 });

--- a/src/components/ogds-header/ogds-header.stories.ts
+++ b/src/components/ogds-header/ogds-header.stories.ts
@@ -168,6 +168,10 @@ export const FullBleed = {
         ogds-primary-nav {
           --ogds-primary-nav-link-color: white;
         }
+
+        [slot="notifications"] {
+          color: white;
+        }
       }
     </style>
     <ogds-header variant="extended" class="full-bleed-example">

--- a/src/components/ogds-header/ogds-header.stories.ts
+++ b/src/components/ogds-header/ogds-header.stories.ts
@@ -140,6 +140,48 @@ export const Basic = {
   `,
 };
 
+export const FullBleed = {
+  name: "Full-bleed rows",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "At desktop widths, background-color custom properties paint their row edge-to-edge automatically, while the row's own content stays inside the `--ogds-header-max-width` column. No extra markup or opt-in is required — this uses the same `--ogds-header-navbar-background-color` and `--ogds-header-nav-primary-row-background-color` props as any other example, just set to colors that contrast with the page.",
+      },
+    },
+  },
+  render: () => html`
+    ${searchStyles} ${secondaryLinksStyles}
+    <style>
+      body {
+        background-color: var(--ogds-theme-color-base-lightest);
+      }
+
+      .full-bleed-example {
+        --ogds-header-max-width: 64rem;
+        --ogds-header-nav-primary-row-background-color: var(
+          --ogds-theme-color-primary-darker
+        );
+        --ogds-header-navbar-background-color: white;
+        --ogds-header-padding-inline: var(--ogds-spacing-2);
+
+        ogds-primary-nav {
+          --ogds-primary-nav-link-color: white;
+        }
+      }
+    </style>
+    <ogds-header variant="extended" class="full-bleed-example">
+      <div slot="logo"><a href="/">Project name</a></div>
+      <div slot="notifications">Notifications</div>
+      <ul class="example-secondary-links" slot="nav-secondary">
+        <li><a href="#">Secondary link</a></li>
+        <li><a href="#">Another secondary link</a></li>
+      </ul>
+      ${genericSearch} ${genericPrimaryNav}
+    </ogds-header>
+  `,
+};
+
 export const EmpXExample = {
   name: "State agency header with info section",
   render: () => html`

--- a/src/components/ogds-header/ogds-header.stories.ts
+++ b/src/components/ogds-header/ogds-header.stories.ts
@@ -143,6 +143,7 @@ export const Basic = {
 export const FullBleed = {
   name: "Full-bleed rows",
   parameters: {
+    layout: "fullscreen",
     docs: {
       description: {
         story:

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -168,6 +168,7 @@ export class OgdsHeader extends LitElement {
         class="nav-secondary"
         part="nav-secondary"
         data-hide-when-empty
+        hidden
         aria-label="Secondary navigation"
       >
         <slot

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -44,6 +44,15 @@ export type OgdsHeaderVariant = "basic" | "extended";
  * @cssprop --ogds-header-padding-inline - Horizontal gutter applied alongside --ogds-header-max-width. Unset by default.
  * @cssprop --ogds-header-row-gap - Vertical gap between the rows of the header grid (logo/secondary nav, info, and primary nav).
  *
+ * @csspart logo - Wrapper around the logo slot.
+ * @csspart navbar - The navbar row (logo + menu button).
+ * @csspart menu-btn - The mobile menu button.
+ * @csspart nav-close - The drawer's close button.
+ * @csspart info - The info row.
+ * @csspart nav-secondary - The secondary nav area.
+ * @csspart nav-primary-row - The row containing the primary nav and notifications.
+ * @csspart notifications - Wrapper around the notifications slot.
+ *
  * @element ogds-header
  */
 export class OgdsHeader extends LitElement {
@@ -149,11 +158,12 @@ export class OgdsHeader extends LitElement {
   render() {
     return html`
       <div class="content">
-        <div class="navbar">
-          <div class="logo"><slot name="logo"></slot></div>
+        <div class="navbar" part="navbar">
+          <div class="logo" part="logo"><slot name="logo"></slot></div>
           <button
             type="button"
             class="menu-btn"
+            part="menu-btn"
             aria-controls="nav"
             aria-expanded="false"
             @click=${this._onMenuBtnClick}
@@ -161,7 +171,7 @@ export class OgdsHeader extends LitElement {
             Menu
           </button>
         </div>
-        <div class="info" hidden>
+        <div class="info" part="info" hidden>
           <slot name="info" @slotchange=${this._onOptionalSlotChange}></slot>
         </div>
         <dialog
@@ -174,18 +184,23 @@ export class OgdsHeader extends LitElement {
           <button
             type="button"
             class="nav-close"
+            part="nav-close"
             aria-label="Close menu"
             @click=${this._onCloseBtnClick}
           ></button>
-          <nav class="nav-secondary" aria-label="Secondary navigation">
+          <nav
+            class="nav-secondary"
+            part="nav-secondary"
+            aria-label="Secondary navigation"
+          >
             <slot
               name="nav-secondary"
               @slotchange=${this._onOptionalSlotChange}
             ></slot>
           </nav>
-          <div class="nav-primary-row">
+          <div class="nav-primary-row" part="nav-primary-row">
             <div class="nav-primary"><slot name="nav-primary"></slot></div>
-            <div class="notifications" hidden>
+            <div class="notifications" part="notifications" hidden>
               <slot
                 name="notifications"
                 @slotchange=${this._onOptionalSlotChange}

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -47,12 +47,15 @@ export type OgdsHeaderVariant = "basic" | "extended";
  * @cssprop --ogds-header-row-gap - Vertical gap between the rows of the header (logo/secondary nav, info, and primary nav).
  *
  * @csspart logo - Wrapper around the logo slot.
- * @csspart navbar - The navbar row (logo + menu button).
+ * @csspart navbar - The navbar row (logo + menu button). At desktop widths its background paints full-bleed; see navbar-inner for the constrained content column inside it.
+ * @csspart navbar-inner - The navbar row's content column (logo + menu button), inset from navbar's edges by --ogds-header-max-width/--ogds-header-padding-inline.
  * @csspart menu-btn - The mobile menu button.
  * @csspart nav-close - The drawer's close button.
- * @csspart info - The info row.
+ * @csspart info - The info row. At desktop widths its background paints full-bleed; see info-inner for the constrained content column inside it.
+ * @csspart info-inner - The info row's content column, inset from info's edges the same way as navbar-inner.
  * @csspart nav-secondary - The secondary nav area.
- * @csspart nav-primary-row - The row containing the primary nav and notifications.
+ * @csspart nav-primary-row - The row containing the primary nav and notifications. At desktop widths its background paints full-bleed; see nav-primary-row-inner for the constrained content column inside it.
+ * @csspart nav-primary-row-inner - The primary-nav row's content column, inset from nav-primary-row's edges the same way as navbar-inner. Only present at desktop widths. Below the breakpoint this row renders inside the drawer, where there's no full-bleed row.
  * @csspart notifications - Wrapper around the notifications slot.
  *
  * @element ogds-header
@@ -149,7 +152,7 @@ export class OgdsHeader extends LitElement {
   /** @ignore */
   private _onOptionalSlotChange(event: Event) {
     const slot = event.target as HTMLSlotElement;
-    const wrapper = slot.closest<HTMLElement>("[part]");
+    const wrapper = slot.closest<HTMLElement>("[data-hide-when-empty]");
     if (!wrapper) return;
     wrapper.hidden = slot.assignedNodes({ flatten: true }).length === 0;
   }
@@ -160,6 +163,7 @@ export class OgdsHeader extends LitElement {
       <nav
         class="nav-secondary"
         part="nav-secondary"
+        data-hide-when-empty
         aria-label="Secondary navigation"
       >
         <slot
@@ -174,7 +178,12 @@ export class OgdsHeader extends LitElement {
   private _renderPrimaryContent() {
     return html`
       <div class="nav-primary"><slot name="nav-primary"></slot></div>
-      <div class="notifications" part="notifications" hidden>
+      <div
+        class="notifications"
+        part="notifications"
+        data-hide-when-empty
+        hidden
+      >
         <slot
           name="notifications"
           @slotchange=${this._onOptionalSlotChange}
@@ -190,7 +199,7 @@ export class OgdsHeader extends LitElement {
     return html`
       <div class="content">
         <div class="navbar-row" part="navbar">
-          <div class="navbar-row-inner">
+          <div class="navbar-row-inner" part="navbar-inner">
             <div class="logo" part="logo"><slot name="logo"></slot></div>
             <button
               type="button"
@@ -206,8 +215,8 @@ export class OgdsHeader extends LitElement {
           ${desktop && extended ? this._renderNavSecondary() : nothing}
         </div>
 
-        <div class="info-row" part="info" hidden>
-          <div class="info-row-inner">
+        <div class="info-row" part="info" data-hide-when-empty hidden>
+          <div class="info-row-inner" part="info-inner">
             <slot name="info" @slotchange=${this._onOptionalSlotChange}></slot>
           </div>
         </div>
@@ -217,7 +226,7 @@ export class OgdsHeader extends LitElement {
             ? html`
                 <div class="primary-row" part="nav-primary-row">
                   ${!extended ? this._renderNavSecondary() : nothing}
-                  <div class="primary-row-inner">
+                  <div class="primary-row-inner" part="nav-primary-row-inner">
                     ${this._renderPrimaryContent()}
                   </div>
                 </div>

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -107,6 +107,11 @@ export class OgdsHeader extends LitElement {
     const dialog = this._navDialog;
     if (!dialog) return;
 
+    /* grabbing focus here (and everything that we do with it below) fixes a critical
+     * accessibility bug where, because we're using a dialog, it grabs focus automatically
+     * in chrome */
+    const previouslyFocused = document.activeElement;
+
     if (this._isDesktop()) {
       if (dialog.open && dialog.matches(":modal")) {
         dialog.close();
@@ -120,6 +125,21 @@ export class OgdsHeader extends LitElement {
       dialog.close();
       requestAnimationFrame(() => dialog.classList.remove("no-transition"));
     }
+
+    setTimeout(() => {
+      if (document.activeElement === previouslyFocused) return;
+
+      if (previouslyFocused instanceof HTMLElement) {
+        if (previouslyFocused === document.body) {
+          const hadTabIndex = document.body.hasAttribute("tabindex");
+          if (!hadTabIndex) document.body.setAttribute("tabindex", "-1");
+          document.body.focus({ preventScroll: true });
+          if (!hadTabIndex) document.body.removeAttribute("tabindex");
+        } else {
+          previouslyFocused.focus({ preventScroll: true });
+        }
+      }
+    }, 0);
   }
 
   /** @ignore */

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -46,6 +46,8 @@ export type OgdsHeaderVariant = "basic" | "extended";
  * @cssprop --ogds-header-padding-inline - Horizontal gutter applied alongside --ogds-header-max-width. Unset by default.
  * @cssprop --ogds-header-row-gap - Vertical gap between the rows of the header (logo/secondary nav, info, and primary nav).
  *
+ * @attr icon - Optional. When present, shows a hamburger icon on the menu button (in addition to its "Menu" label).
+ *
  * @csspart logo - Wrapper around the logo slot.
  * @csspart navbar - The navbar row (logo + menu button). At desktop widths its background paints full-bleed; see navbar-inner for the constrained content column inside it.
  * @csspart navbar-inner - The navbar row's content column (logo + menu button), inset from navbar's edges by --ogds-header-max-width/--ogds-header-padding-inline.
@@ -62,6 +64,8 @@ export type OgdsHeaderVariant = "basic" | "extended";
  */
 export class OgdsHeader extends LitElement {
   @property({ reflect: true }) variant: OgdsHeaderVariant = "extended";
+
+  @property({ type: Boolean, reflect: true }) icon = false;
 
   /*
    * Reactive: at desktop widths, nav-secondary/nav-primary/notifications
@@ -203,7 +207,7 @@ export class OgdsHeader extends LitElement {
             <div class="logo" part="logo"><slot name="logo"></slot></div>
             <button
               type="button"
-              class="menu-btn"
+              class="menu-btn ${this.icon ? "with-icon" : ""}"
               part="menu-btn"
               aria-controls="nav"
               aria-expanded="false"

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -28,19 +28,21 @@ export type OgdsHeaderVariant = "basic" | "extended";
  * @slot notifications - Optional. Content like an account or notifications indicator shown alongside the primary nav.
  * @slot nav-secondary - Optional. Secondary links and/or a search form. At desktop widths (extended variant), shown aligned with the logo; below the desktop breakpoint it folds into the drawer with the primary nav.
  *
- * @cssprop --ogds-header-navbar-background-color - Background color of the navbar row (logo + menu button). Transparent by default.
- * @cssprop --ogds-header-info-background-color - Background color of the info row. Transparent by default.
- * @cssprop --ogds-header-nav-primary-row-background-color - Background color of the row containing the primary nav and notifications. Transparent by default.
- * @cssprop --ogds-header-nav-secondary-background-color - Background color of the secondary nav area. Transparent by default.
+ * @cssprop --ogds-header-navbar-background-color - Background color of the navbar row (logo + menu button). Transparent by default. At desktop widths, paints edge-to-edge ("full-bleed") even though the row's content stays in the constrained column.
+ * @cssprop --ogds-header-info-background-color - Background color of the info row. Transparent by default. At desktop widths, paints edge-to-edge ("full-bleed") even though the row's content stays in the constrained column.
+ * @cssprop --ogds-header-nav-primary-row-background-color - Background color of the row containing the primary nav and notifications. Transparent by default. At desktop widths, paints edge-to-edge ("full-bleed") even though the row's content stays in the constrained column.
+ * @cssprop --ogds-header-nav-secondary-background-color - Background color of the secondary nav area. At desktop widths, paints edge-to-edge (full-bleed) on the outward-facing side (away from the row it shares with the navbar in extended, or the primary nav in basic). Defaults to that other row's own background color (falling back to transparent if neither is set), so setting just one of the two already produces one seamless band
  * @cssprop --ogds-header-menu-btn-background-color - Background color of the menu button.
  * @cssprop --ogds-header-menu-btn-color - Text/icon color of the menu button.
+ * @cssprop --ogds-header-menu-btn-padding-inline-end - The menu button's own edge inset below the desktop breakpoint, independent of the logo's. Defaults to --ogds-header-padding-inline (matching the logo). Set to 0 to make the button flush with the viewport edge while the logo keeps its normal inset.
  * @cssprop --ogds-header-nav-background-color - Background color of the navigation drawer.
  * @cssprop --ogds-header-overlay-color - Color of the backdrop behind the open drawer.
- * @cssprop --ogds-header-divider-color - Color of hairline dividers/borders.
+ * @cssprop --ogds-header-divider-color - Color of borders (e.g. the info row's border, and the default for --ogds-header-nav-primary-row-divider-color).
+ * @cssprop --ogds-header-nav-primary-row-divider-color - Color of the primary-nav row's own top divider. Defaults to --ogds-header-divider-color. Set independently (e.g. to transparent) to suppress just this divider without affecting the info row's.
  * @cssprop --ogds-header-drawer-width - Width of the navigation drawer below the desktop breakpoint.
  * @cssprop --ogds-header-icon-close-size - Height and width of the drawer's close icon.
  * @cssprop --ogds-header-icon-menu-size - Height and width of the menu button's icon.
- * @cssprop --ogds-header-max-width - Max width of the header's content, centered with auto margins (like a USWDS grid container). Unset by default, so content spans the full width of the host.
+ * @cssprop --ogds-header-max-width - Max width of the header's content column, centered with auto margins (like a USWDS .grid-container). Unset by default, so content spans the full width of the host. Sizing matches .grid-container's convention: the column itself is max-width wide, and --ogds-header-padding-inline is added outside that (rendered width caps at max-width + 2 * padding-inline) — so reuse the same max-width value you use for a page's .grid-container to align this header with it.
  * @cssprop --ogds-header-padding-inline - Horizontal gutter applied alongside --ogds-header-max-width. Unset by default.
  * @cssprop --ogds-header-row-gap - Vertical gap between the rows of the header grid (logo/secondary nav, info, and primary nav).
  *

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -130,14 +130,14 @@ export class OgdsHeader extends LitElement {
       if (document.activeElement === previouslyFocused) return;
 
       if (previouslyFocused instanceof HTMLElement) {
-        if (previouslyFocused === document.body) {
-          const hadTabIndex = document.body.hasAttribute("tabindex");
-          if (!hadTabIndex) document.body.setAttribute("tabindex", "-1");
-          document.body.focus({ preventScroll: true });
-          if (!hadTabIndex) document.body.removeAttribute("tabindex");
-        } else {
-          previouslyFocused.focus({ preventScroll: true });
-        }
+        previouslyFocused.focus({ preventScroll: true });
+      }
+
+      if (document.activeElement !== previouslyFocused) {
+        const hadTabIndex = document.body.hasAttribute("tabindex");
+        if (!hadTabIndex) document.body.setAttribute("tabindex", "-1");
+        document.body.focus({ preventScroll: true });
+        if (!hadTabIndex) document.body.removeAttribute("tabindex");
       }
     }, 0);
   }

--- a/src/components/ogds-header/ogds-header.ts
+++ b/src/components/ogds-header/ogds-header.ts
@@ -1,5 +1,5 @@
-import { LitElement, css, html, unsafeCSS } from "lit";
-import { property } from "lit/decorators.js";
+import { LitElement, css, html, nothing, unsafeCSS } from "lit";
+import { property, state } from "lit/decorators.js";
 
 import cssFileStyles from "./ogds-header.css";
 import iconMenu from "../../shared/icons/menu.svg";
@@ -31,7 +31,7 @@ export type OgdsHeaderVariant = "basic" | "extended";
  * @cssprop --ogds-header-navbar-background-color - Background color of the navbar row (logo + menu button). Transparent by default. At desktop widths, paints edge-to-edge ("full-bleed") even though the row's content stays in the constrained column.
  * @cssprop --ogds-header-info-background-color - Background color of the info row. Transparent by default. At desktop widths, paints edge-to-edge ("full-bleed") even though the row's content stays in the constrained column.
  * @cssprop --ogds-header-nav-primary-row-background-color - Background color of the row containing the primary nav and notifications. Transparent by default. At desktop widths, paints edge-to-edge ("full-bleed") even though the row's content stays in the constrained column.
- * @cssprop --ogds-header-nav-secondary-background-color - Background color of the secondary nav area. At desktop widths, paints edge-to-edge (full-bleed) on the outward-facing side (away from the row it shares with the navbar in extended, or the primary nav in basic). Defaults to that other row's own background color (falling back to transparent if neither is set), so setting just one of the two already produces one seamless band
+ * @cssprop --ogds-header-nav-secondary-background-color - Background color of the secondary nav area. At desktop widths, paints edge-to-edge ("full-bleed") on the outward-facing side (away from the row it shares with the navbar in extended, or the primary nav in basic). Defaults to that other row's own background color (falling back to transparent if neither is set), so setting just one of the two already produces one shared background color.
  * @cssprop --ogds-header-menu-btn-background-color - Background color of the menu button.
  * @cssprop --ogds-header-menu-btn-color - Text/icon color of the menu button.
  * @cssprop --ogds-header-menu-btn-padding-inline-end - The menu button's own edge inset below the desktop breakpoint, independent of the logo's. Defaults to --ogds-header-padding-inline (matching the logo). Set to 0 to make the button flush with the viewport edge while the logo keeps its normal inset.
@@ -44,7 +44,7 @@ export type OgdsHeaderVariant = "basic" | "extended";
  * @cssprop --ogds-header-icon-menu-size - Height and width of the menu button's icon.
  * @cssprop --ogds-header-max-width - Max width of the header's content column, centered with auto margins (like a USWDS .grid-container). Unset by default, so content spans the full width of the host. Sizing matches .grid-container's convention: the column itself is max-width wide, and --ogds-header-padding-inline is added outside that (rendered width caps at max-width + 2 * padding-inline) — so reuse the same max-width value you use for a page's .grid-container to align this header with it.
  * @cssprop --ogds-header-padding-inline - Horizontal gutter applied alongside --ogds-header-max-width. Unset by default.
- * @cssprop --ogds-header-row-gap - Vertical gap between the rows of the header grid (logo/secondary nav, info, and primary nav).
+ * @cssprop --ogds-header-row-gap - Vertical gap between the rows of the header (logo/secondary nav, info, and primary nav).
  *
  * @csspart logo - Wrapper around the logo slot.
  * @csspart navbar - The navbar row (logo + menu button).
@@ -60,12 +60,23 @@ export type OgdsHeaderVariant = "basic" | "extended";
 export class OgdsHeader extends LitElement {
   @property({ reflect: true }) variant: OgdsHeaderVariant = "extended";
 
+  /*
+   * Reactive: at desktop widths, nav-secondary/nav-primary/notifications
+   * render directly in the layout (no <dialog> involved at all). Below the
+   * breakpoint, the same slots render inside a <dialog> instead, opened
+   * modally via the menu button. <dialog> is never shown non-modally - that
+   * used to be how this component made its content render at desktop too,
+   * via `dialog.show()` + `display: contents`, but non-modal show() runs
+   * the browser's "dialog focusing steps" regardless of whether a user
+   * asked for anything to be focused, which cost a lot of complexity (see
+   * git history) to work around. Splitting the desktop/mobile structure
+   * like this means <dialog> is only ever used for what it's actually for:
+   * the real, user-initiated modal drawer.
+   */
+  @state() private _isDesktopMode = true;
+
   /** @ignore */
   private _desktopQuery: MediaQueryList | null = null;
-  /** @ignore */
-  private _navDialog: HTMLDialogElement | null = null;
-  /** @ignore */
-  private _menuBtn: HTMLButtonElement | null = null;
 
   static styles = [localStyles, cssFileStyles];
 
@@ -79,6 +90,7 @@ export class OgdsHeader extends LitElement {
 
     if (typeof matchMedia === "function") {
       this._desktopQuery = matchMedia(DESKTOP_QUERY);
+      this._isDesktopMode = this._desktopQuery.matches;
       this._desktopQuery.addEventListener("change", this._onViewportChange);
     }
   }
@@ -88,59 +100,25 @@ export class OgdsHeader extends LitElement {
     this._desktopQuery?.removeEventListener("change", this._onViewportChange);
   }
 
-  override firstUpdated() {
-    this._navDialog = this.renderRoot.querySelector("dialog");
-    this._menuBtn = this.renderRoot.querySelector(".menu-btn");
-    this._syncNavToViewport();
+  /** @ignore */
+  private get _navDialog(): HTMLDialogElement | null {
+    return this.renderRoot.querySelector("dialog");
   }
 
   /** @ignore */
-  private _isDesktop() {
-    return this._desktopQuery?.matches ?? true;
+  private get _menuBtn(): HTMLButtonElement | null {
+    return this.renderRoot.querySelector(".menu-btn");
   }
 
   /** @ignore */
-  private _onViewportChange = () => this._syncNavToViewport();
-
-  /** @ignore */
-  private _syncNavToViewport() {
-    const dialog = this._navDialog;
-    if (!dialog) return;
-
-    /* grabbing focus here (and everything that we do with it below) fixes a critical
-     * accessibility bug where, because we're using a dialog, it grabs focus automatically
-     * in chrome */
-    const previouslyFocused = document.activeElement;
-
-    if (this._isDesktop()) {
-      if (dialog.open && dialog.matches(":modal")) {
-        dialog.close();
-      }
-      if (!dialog.open) {
-        dialog.show();
-      }
+  private _onViewportChange = () => {
+    const nowDesktop = this._desktopQuery?.matches ?? true;
+    if (nowDesktop && !this._isDesktopMode) {
+      this._navDialog?.close();
       this._menuBtn?.setAttribute("aria-expanded", "false");
-    } else if (dialog.open && !dialog.matches(":modal")) {
-      dialog.classList.add("no-transition");
-      dialog.close();
-      requestAnimationFrame(() => dialog.classList.remove("no-transition"));
     }
-
-    setTimeout(() => {
-      if (document.activeElement === previouslyFocused) return;
-
-      if (previouslyFocused instanceof HTMLElement) {
-        previouslyFocused.focus({ preventScroll: true });
-      }
-
-      if (document.activeElement !== previouslyFocused) {
-        const hadTabIndex = document.body.hasAttribute("tabindex");
-        if (!hadTabIndex) document.body.setAttribute("tabindex", "-1");
-        document.body.focus({ preventScroll: true });
-        if (!hadTabIndex) document.body.removeAttribute("tabindex");
-      }
-    }, 0);
-  }
+    this._isDesktopMode = nowDesktop;
+  };
 
   /** @ignore */
   private _onMenuBtnClick() {
@@ -156,7 +134,6 @@ export class OgdsHeader extends LitElement {
 
   /** @ignore */
   private _onDialogClose() {
-    if (this._isDesktop()) return;
     this._menuBtn?.setAttribute("aria-expanded", "false");
   }
 
@@ -172,64 +149,101 @@ export class OgdsHeader extends LitElement {
   /** @ignore */
   private _onOptionalSlotChange(event: Event) {
     const slot = event.target as HTMLSlotElement;
-    const wrapper = slot.parentElement;
+    const wrapper = slot.closest<HTMLElement>("[part]");
     if (!wrapper) return;
     wrapper.hidden = slot.assignedNodes({ flatten: true }).length === 0;
   }
 
+  /** @ignore */
+  private _renderNavSecondary() {
+    return html`
+      <nav
+        class="nav-secondary"
+        part="nav-secondary"
+        aria-label="Secondary navigation"
+      >
+        <slot
+          name="nav-secondary"
+          @slotchange=${this._onOptionalSlotChange}
+        ></slot>
+      </nav>
+    `;
+  }
+
+  /** @ignore */
+  private _renderPrimaryContent() {
+    return html`
+      <div class="nav-primary"><slot name="nav-primary"></slot></div>
+      <div class="notifications" part="notifications" hidden>
+        <slot
+          name="notifications"
+          @slotchange=${this._onOptionalSlotChange}
+        ></slot>
+      </div>
+    `;
+  }
+
   render() {
+    const desktop = this._isDesktopMode;
+    const extended = this.variant === "extended";
+
     return html`
       <div class="content">
-        <div class="navbar" part="navbar">
-          <div class="logo" part="logo"><slot name="logo"></slot></div>
-          <button
-            type="button"
-            class="menu-btn"
-            part="menu-btn"
-            aria-controls="nav"
-            aria-expanded="false"
-            @click=${this._onMenuBtnClick}
-          >
-            Menu
-          </button>
-        </div>
-        <div class="info" part="info" hidden>
-          <slot name="info" @slotchange=${this._onOptionalSlotChange}></slot>
-        </div>
-        <dialog
-          id="nav"
-          class="nav"
-          aria-label="Header navigation"
-          @close=${this._onDialogClose}
-          @click=${this._onDialogClick}
-        >
-          <button
-            type="button"
-            class="nav-close"
-            part="nav-close"
-            aria-label="Close menu"
-            @click=${this._onCloseBtnClick}
-          ></button>
-          <nav
-            class="nav-secondary"
-            part="nav-secondary"
-            aria-label="Secondary navigation"
-          >
-            <slot
-              name="nav-secondary"
-              @slotchange=${this._onOptionalSlotChange}
-            ></slot>
-          </nav>
-          <div class="nav-primary-row" part="nav-primary-row">
-            <div class="nav-primary"><slot name="nav-primary"></slot></div>
-            <div class="notifications" part="notifications" hidden>
-              <slot
-                name="notifications"
-                @slotchange=${this._onOptionalSlotChange}
-              ></slot>
-            </div>
+        <div class="navbar-row" part="navbar">
+          <div class="navbar-row-inner">
+            <div class="logo" part="logo"><slot name="logo"></slot></div>
+            <button
+              type="button"
+              class="menu-btn"
+              part="menu-btn"
+              aria-controls="nav"
+              aria-expanded="false"
+              @click=${this._onMenuBtnClick}
+            >
+              Menu
+            </button>
           </div>
-        </dialog>
+          ${desktop && extended ? this._renderNavSecondary() : nothing}
+        </div>
+
+        <div class="info-row" part="info" hidden>
+          <div class="info-row-inner">
+            <slot name="info" @slotchange=${this._onOptionalSlotChange}></slot>
+          </div>
+        </div>
+
+        ${
+          desktop
+            ? html`
+                <div class="primary-row" part="nav-primary-row">
+                  ${!extended ? this._renderNavSecondary() : nothing}
+                  <div class="primary-row-inner">
+                    ${this._renderPrimaryContent()}
+                  </div>
+                </div>
+              `
+            : html`
+                <dialog
+                  id="nav"
+                  class="nav"
+                  aria-label="Header navigation"
+                  @close=${this._onDialogClose}
+                  @click=${this._onDialogClick}
+                >
+                  <button
+                    type="button"
+                    class="nav-close"
+                    part="nav-close"
+                    aria-label="Close menu"
+                    @click=${this._onCloseBtnClick}
+                  ></button>
+                  ${this._renderNavSecondary()}
+                  <div class="nav-primary-row" part="nav-primary-row">
+                    ${this._renderPrimaryContent()}
+                  </div>
+                </dialog>
+              `
+        }
       </div>
     `;
   }

--- a/src/components/ogds-primary-nav/docs.mdx
+++ b/src/components/ogds-primary-nav/docs.mdx
@@ -37,8 +37,10 @@ The primary nav lists the main sections of a site. On narrow viewports its subme
 </ogds-primary-nav>
 ```
 
-Add `aria-current="page"` to the current page's `<a>` to show the current-page indicator. Because the logic for knowing where the user is in the application
-will depend heavily on the implementation, the app consuming the component is responsible for managing the `aria-current` attribute.
+Add `aria-current="page"` to the current page's `<a>` to show the current-page indicator. The same attribute works on a `<summary>` too, but in this case it marks the current
+_section_ when the current page lives inside a submenu rather than being a top-level link. The indicator shows whether that submenu is open or closed. Because
+the logic for knowing where the user is in the application will depend heavily on the implementation, the app consuming the component is responsible for
+managing the `aria-current` attribute.
 
 ## Guidance
 
@@ -57,6 +59,35 @@ Subnavs use the browser-native `<details>`/`<summary>` elements, so they open an
 1. **Native details/summary.** Subnavs keep working without JavaScript because they use the native `<details>` element (besides exceptions noted above).
 2. **Styles.** As long as the component's styles are pulled into your application, the visual styling still works without JavaScript.
 3. **Class-based equivalent.** You can substitute `<div class="ogds-primary-nav">` in place of `<ogds-primary-nav>`. These are equivalent for styling, but since there's no JavaScript running you'll need to add `role="navigation"` and `aria-label` yourself, and give shared `name` attributes to top-level `<details>` elements for exclusive subnavs.
+
+## Troubleshooting
+
+### The chevron/dropdown toggle is missing, or hover/row alignment looks broken
+
+Check for an unlayered `summary { display: ... }` rule elsewhere on the page
+(USWDS's own reset includes one). Unlayered CSS always wins over this
+component's layered styles regardless of specificity or source order, so a rule
+like that can silently override the `display: flex` the chevron icon, hover
+state, and row alignment all depend on. This component ships a small unlayered
+escape hatch specifically for `summary`'s `display` to guard against the common
+case, but a sufficiently specific unlayered override elsewhere can still beat
+it.
+
+### A submenu dropdown renders behind other page content
+
+The dropdown relies on an ambient `z-index` that you're expected to set
+yourself. There's no built-in value. That's fragile in a specific way: if any
+element between the nav and the page root establishes its own stacking context,
+that ancestor traps the nav's `z-index` inside it, so the dropdown can no
+longer compete against content outside that ancestor no matter how high you set
+it.
+
+Obviously `position` with a `z-index` is the most common source of this
+behavior, but there are plenty of other, subtler ways to create new stacking
+contexts: `transform` (including a harmless identity transform like
+`translateZ(0)`, which you might add just to trigger GPU-acceleration),
+`filter`, `opacity` below `1`, `will-change`, `isolation: isolate`, and
+`contain: layout` or `paint`.
 
 ---
 

--- a/src/components/ogds-primary-nav/index.ts
+++ b/src/components/ogds-primary-nav/index.ts
@@ -37,8 +37,9 @@ let instanceCount = 0;
  * @cssprop --ogds-primary-nav-link-color - Text color for links and submenu toggles.
  * @cssprop --ogds-primary-nav-link-hover-background-color - Background color on hover below the desktop breakpoint.
  * @cssprop --ogds-primary-nav-link-hover-color - Text color on hover at the desktop breakpoint.
- * @cssprop --ogds-primary-nav-submenu-background-color - Background color of a submenu panel, and of its open toggle at the desktop breakpoint.
- * @cssprop --ogds-primary-nav-submenu-link-color - Text color for links inside a submenu.
+ * @cssprop --ogds-primary-nav-submenu-background-color - Background color of a submenu panel at the desktop size (where it covers page content), and of its parent nav item while open. At mobile widths, the subnav background is transparent instead to show the drawer background.
+ * @cssprop --ogds-primary-nav-submenu-divider-color - Border color between subnav items in the nav drawer.
+ * @cssprop --ogds-primary-nav-submenu-link-color - Text color for links inside a submenu at the desktop breakpoint. Below the desktop breakpoint, submenu links use --ogds-primary-nav-link-color instead, to keep sufficient contrast against the submenu's transparent background.
  *
  * @slot - Expects a single `<ul>` of `<li>` items, each containing either an `<a>` or a `<details>` submenu.
  * @element ogds-primary-nav

--- a/src/components/ogds-primary-nav/index.ts
+++ b/src/components/ogds-primary-nav/index.ts
@@ -115,12 +115,18 @@ export class OgdsPrimaryNav extends LitElement {
   private _onKeydown = (event: KeyboardEvent) => {
     if (event.key !== "Escape") return;
 
-    const openSubmenu = this._submenus.find((details) => details.open);
-    if (openSubmenu) {
-      openSubmenu.open = false;
-      openSubmenu.querySelector<HTMLElement>(":scope > summary")?.focus();
-      event.stopPropagation();
-    }
+    const openSubmenus = this._submenus.filter((details) => details.open);
+    if (openSubmenus.length === 0) return;
+
+    const active = document.activeElement;
+    const openSubmenu =
+      openSubmenus.find(
+        (details) => active instanceof Node && details.contains(active),
+      ) ?? openSubmenus[0];
+
+    openSubmenu.open = false;
+    openSubmenu.querySelector<HTMLElement>(":scope > summary")?.focus();
+    event.stopPropagation();
   };
 
   render() {

--- a/src/components/ogds-primary-nav/ogds-primary-nav.css
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.css
@@ -27,6 +27,10 @@
       --ogds-theme-color-primary-darker,
       #162e51
     );
+    --ogds-primary-nav-submenu-divider-color: var(
+      --ogds-theme-color-base-lighter,
+      #dfe1e2
+    );
     --ogds-primary-nav-submenu-link-color: var(
       --ogds-theme-text-reverse-color,
       #fff
@@ -121,23 +125,31 @@
     }
 
     details > ul {
-      background-color: var(--ogds-primary-nav-submenu-background-color);
+      background-color: transparent;
       padding-block: var(--ogds-spacing-1, 0.5rem);
     }
 
+    details > ul > li {
+      border-block-start: 1px solid
+        var(--ogds-primary-nav-submenu-divider-color);
+    }
+
     details > ul a {
-      color: var(--ogds-primary-nav-submenu-link-color);
+      color: var(--ogds-primary-nav-link-color);
       font-weight: 400;
       padding-inline-start: var(--ogds-spacing-4, 2rem);
 
       &:hover {
-        background-color: transparent;
         text-decoration: underline;
       }
 
       &:focus-visible {
         outline-offset: -0.25rem;
       }
+    }
+
+    details > ul > li:has(> a:hover) {
+      background-color: var(--ogds-primary-nav-link-hover-background-color);
     }
 
     /**
@@ -174,12 +186,22 @@
       }
 
       details > ul {
+        background-color: var(--ogds-primary-nav-submenu-background-color);
         inline-size: 15rem;
         inset-inline-start: 0;
         position: absolute;
         top: 100%;
 
+        > li {
+          border-block-start: none;
+
+          &:has(> a:hover) {
+            background-color: transparent;
+          }
+        }
+
         a {
+          color: var(--ogds-primary-nav-submenu-link-color);
           padding-inline-start: 0;
         }
       }

--- a/src/components/ogds-primary-nav/ogds-primary-nav.css
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.css
@@ -59,7 +59,8 @@
       position: relative;
     }
 
-    > ul > li:first-child a {
+    > ul > li:first-child a,
+    > ul > li:first-child > details > summary {
       padding-inline-start: 0;
     }
 
@@ -81,7 +82,8 @@
 
     > ul > li > a:hover,
     > ul > li > a[aria-current="page"],
-    > ul > li > details:not([open]) > summary:hover {
+    > ul > li > details:not([open]) > summary:hover,
+    > ul > li > details > summary[aria-current="page"] {
       position: relative;
 
       &::before {
@@ -183,4 +185,11 @@
       }
     }
   }
+}
+
+/* keeping this rule outside of the layer because layered CSS loses
+ * to unlayered in a specificity fight, so this was clobbered by the
+ * USWDS reset which we can expect to be a recurring issue */
+:is(.ogds-primary-nav, ogds-primary-nav) summary {
+  display: flex;
 }

--- a/src/components/ogds-primary-nav/ogds-primary-nav.spec.ts
+++ b/src/components/ogds-primary-nav/ogds-primary-nav.spec.ts
@@ -162,6 +162,41 @@ describe("keyboard", () => {
     expect(details.open).toBe(false);
     expect(document.activeElement).toBe(details.querySelector("summary"));
   });
+
+  it("on Escape key press with multiple submenus open (distinct author-supplied names), closes the one focus is inside", async () => {
+    const el = mount(`
+      <ogds-primary-nav>
+        <ul>
+          <li>
+            <details name="one">
+              <summary>Section one</summary>
+              <ul><li><a href="/one/a">One A</a></li></ul>
+            </details>
+          </li>
+          <li>
+            <details name="two">
+              <summary>Section two</summary>
+              <ul><li><a href="/two/a">Two A</a></li></ul>
+            </details>
+          </li>
+        </ul>
+      </ogds-primary-nav>
+    `);
+    await el.updateComplete;
+    const [first, second] = Array.from(el.querySelectorAll("details"));
+    first.open = true;
+    second.open = true;
+    const secondLink = second.querySelector("a") as HTMLAnchorElement;
+    secondLink.focus();
+
+    el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+
+    expect(second.open).toBe(false);
+    expect(first.open).toBe(true);
+    expect(document.activeElement).toBe(second.querySelector("summary"));
+  });
 });
 
 describe("stylesheet adoption", () => {


### PR DESCRIPTION
# Summary

Dramatically simplified the header implementation while improving its reusability and squashing numerous bugs; added some default styling to the mobile subnav in the primary nav as well; finally, improved documentation around using the component in a USWDS site and potential gotchas.

## Problem statement

The first iteration of the header component worked, but it was very complicated and required a ton of workarounds. Using `<dialog>` to handle the mobile nav drawer is a good idea, but putting everything inside of a `<dialog>` and trying to make that work for both desktop & mobile sizes was immensely complicated (and immensely buggy).

## Solution

This PR really takes advantage of the fact that we're using Lit. Because this was always a JS-required component, we don't have to architect it like a CSS-only component. So much of the complexity of the first iteration of this component (and earlier commits on this branch) came from trying to make `<dialog>` behave correctly at desktop width and when transitioning between breakpoints. As such, this PR just uses different templates at different breakpoints, which we can do easily with Lit. Because the consumer-authored content lives in slots, it can easily be shuttled back & forth between the two templates, and we no longer need CSS that can accommodate one shared template with very different layouts.

## Major changes

The biggest change is the render switch described above. By splitting the templates, we were able to remove almost all of the complexity in the CSS.

The first iteration of this component was fussy and didn't always integrate well with existing USWDS sites. It took a lot of custom code to get things like full-width, full-bleed, centered (USWDS `.grid-container`-style) layouts working. Along the way to fixing that, the CSS spiraled out of control, requiring a lot of verbose breadcrumb comments just to be able to keep track of how everything hung together.

Further, while `<dialog>` let us avoid implementing our own focus-handling, inert backdrop, and keyboard navigation, it also introduced a lot of focus-stealing bugs that took a lot of custom JS to fix, so ultimately a wash (or worse) as far as JS complexity. The template split eliminated that complexity entirely.

## Testing and review

Check out the storybook and make sure there were no regressions. While I was working on this, I was also implementing the logged-out site header with it in parallel, so I caught many, many things along the way, but there could definitely be things I missed.